### PR TITLE
Unnest column description

### DIFF
--- a/academic/academic.json
+++ b/academic/academic.json
@@ -4,259 +4,241 @@
             {
                 "data_type": "bigint",
                 "column_name": "cited",
-                "column_description": ["ID of the publication being cited"]
+                "column_description": "ID of the publication being cited"
             },
             {
                 "data_type": "bigint",
                 "column_name": "citing",
-                "column_description": ["ID of the publication that is citing another publication"]
+                "column_description": "ID of the publication that is citing another publication"
             }
         ],
         "author": [
             {
                 "data_type": "bigint",
                 "column_name": "aid",
-                "column_description": ["Unique identifier for each author"]
+                "column_description": "Unique identifier for each author"
             },
             {
                 "data_type": "bigint",
                 "column_name": "oid",
-                "column_description": ["Foreign key referencing the organization the author belongs to"]
+                "column_description": "Foreign key referencing the organization the author belongs to"
             },
             {
                 "data_type": "text",
                 "column_name": "homepage",
-                "column_description": ["URL of the author's personal website"]
+                "column_description": "URL of the author's personal website"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["Name of the author"]
+                "column_description": "Name of the author"
             }
         ],
         "domain": [
             {
                 "data_type": "bigint",
                 "column_name": "did",
-                "column_description": ["Unique identifier for a domain"]
+                "column_description": "Unique identifier for a domain"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["Name of the domain"]
+                "column_description": "Name of the domain"
             }
         ],
         "writes": [
             {
                 "data_type": "bigint",
                 "column_name": "aid",
-                "column_description": ["Foreign key referencing the author table's primary key"]
+                "column_description": "Foreign key referencing the author table's primary key"
             },
             {
                 "data_type": "bigint",
                 "column_name": "pid",
-                "column_description": ["Foreign key referencing the publication table's primary key"]
+                "column_description": "Foreign key referencing the publication table's primary key"
             }
         ],
         "journal": [
             {
                 "data_type": "bigint",
                 "column_name": "jid",
-                "column_description": ["Unique identifier for a journal"]
+                "column_description": "Unique identifier for a journal"
             },
             {
                 "data_type": "text",
                 "column_name": "homepage",
-                "column_description": ["The homepage URL for the journal"]
+                "column_description": "The homepage URL for the journal"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["The name of the journal"]
+                "column_description": "The name of the journal"
             }
         ],
         "keyword": [
             {
                 "data_type": "bigint",
                 "column_name": "kid",
-                "column_description": ["Unique identifier for a keyword"]
+                "column_description": "Unique identifier for a keyword"
             },
             {
                 "data_type": "text",
                 "column_name": "keyword",
-                "column_description": ["The actual keyword"]
+                "column_description": "The actual keyword"
             }
         ],
         "conference": [
             {
                 "data_type": "bigint",
                 "column_name": "cid",
-                "column_description": ["Unique identifier for a conference"]
+                "column_description": "Unique identifier for a conference"
             },
             {
                 "data_type": "text",
                 "column_name": "homepage",
-                "column_description": ["The homepage URL for the conference"]
+                "column_description": "The homepage URL for the conference"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["The name of the conference"]
+                "column_description": "The name of the conference"
             }
         ],
         "publication": [
             {
                 "data_type": "bigint",
                 "column_name": "year",
-                "column_description": ["The year of publication"]
+                "column_description": "The year of publication"
             },
             {
                 "data_type": "bigint",
                 "column_name": "cid",
-                "column_description": ["The ID of the conference where the publication was presented"]
+                "column_description": "The ID of the conference where the publication was presented"
             },
             {
                 "data_type": "bigint",
                 "column_name": "citation_num",
-                "column_description": ["The number of citations received by the publication"]
+                "column_description": "The number of citations received by the publication"
             },
             {
                 "data_type": "bigint",
                 "column_name": "jid",
-                "column_description": ["The ID of the journal where the publication was published"]
+                "column_description": "The ID of the journal where the publication was published"
             },
             {
                 "data_type": "bigint",
                 "column_name": "pid",
-                "column_description": ["The unique ID of the publication"]
+                "column_description": "The unique ID of the publication"
             },
             {
                 "data_type": "bigint",
                 "column_name": "reference_num",
-                "column_description": ["The number of references cited by the publication"]
+                "column_description": "The number of references cited by the publication"
             },
             {
                 "data_type": "text",
                 "column_name": "title",
-                "column_description": ["The title of the publication"]
+                "column_description": "The title of the publication"
             },
             {
                 "data_type": "text",
                 "column_name": "abstract",
-                "column_description": ["The abstract of the publication"]
+                "column_description": "The abstract of the publication"
             }
         ],
         "organization": [
             {
                 "data_type": "bigint",
                 "column_name": "oid",
-                "column_description": ["Unique identifier for the organization"]
+                "column_description": "Unique identifier for the organization"
             },
             {
                 "data_type": "text",
                 "column_name": "continent",
-                "column_description": ["Continent where the organization is located"]
+                "column_description": "Continent where the organization is located"
             },
             {
                 "data_type": "text",
                 "column_name": "homepage",
-                "column_description": ["URL of the organization's homepage"]
+                "column_description": "URL of the organization's homepage"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["Name of the organization"]
+                "column_description": "Name of the organization"
             }
         ],
         "domain_author": [
             {
                 "data_type": "bigint",
                 "column_name": "aid",
-                "column_description": ["Foreign key referencing the author table's primary key"]
+                "column_description": "Foreign key referencing the author table's primary key"
             },
             {
                 "data_type": "bigint",
                 "column_name": "did",
-                "column_description": ["Foreign key referencing the domain table's primary key"]
+                "column_description": "Foreign key referencing the domain table's primary key"
             }
         ],
         "domain_journal": [
             {
                 "data_type": "bigint",
                 "column_name": "did",
-                "column_description": ["Foreign key referencing the domain table's primary key"]
+                "column_description": "Foreign key referencing the domain table's primary key"
             },
             {
                 "data_type": "bigint",
                 "column_name": "jid",
-                "column_description": ["Foreign key referencing the journal table's primary key"]
+                "column_description": "Foreign key referencing the journal table's primary key"
             }
         ],
         "domain_keyword": [
             {
                 "data_type": "bigint",
                 "column_name": "did",
-                "column_description": ["Foreign key referencing the 'did' column of the 'domain' table"]
+                "column_description": "Foreign key referencing the 'did' column of the 'domain' table"
             },
             {
                 "data_type": "bigint",
                 "column_name": "kid",
-                "column_description": ["Foreign key referencing the 'kid' column of the 'keyword' table"]
+                "column_description": "Foreign key referencing the 'kid' column of the 'keyword' table"
             }
         ],
         "domain_conference": [
             {
                 "data_type": "bigint",
                 "column_name": "cid",
-                "column_description": ["Foreign key referencing the cid column in the conference table"]
+                "column_description": "Foreign key referencing the cid column in the conference table"
             },
             {
                 "data_type": "bigint",
                 "column_name": "did",
-                "column_description": ["Foreign key referencing the did column in the domain table"]
+                "column_description": "Foreign key referencing the did column in the domain table"
             }
         ],
         "domain_publication": [
             {
                 "data_type": "bigint",
                 "column_name": "did",
-                "column_description": ["Foreign key referencing the domain table's primary key column (did)"]
+                "column_description": "Foreign key referencing the domain table's primary key column (did)"
             },
             {
                 "data_type": "bigint",
                 "column_name": "pid",
-                "column_description": ["Foreign key referencing the publication table's primary key column (pid)"]
+                "column_description": "Foreign key referencing the publication table's primary key column (pid)"
             }
         ],
         "publication_keyword": [
             {
                 "data_type": "bigint",
                 "column_name": "pid",
-                "column_description": ["Foreign key referencing the publication table's primary key (pid)"]
+                "column_description": "Foreign key referencing the publication table's primary key (pid)"
             },
             {
                 "data_type": "bigint",
                 "column_name": "kid",
-                "column_description": ["Foreign key referencing the keyword table's primary key (kid)"]
+                "column_description": "Foreign key referencing the keyword table's primary key (kid)"
             }
         ]
-    },
-    "glossary": "When listing results, please use DISTINCT to avoid duplicate results.",
-    "table_descriptions": {
-        "cite": "The \"cite\" table is used to store information about citations between publications. It has two columns: \"cited\" which represents the ID of the publication being cited, and \"citing\" which represents the ID of the publication that is citing another publication. This table can be joined with other tables such as \"publication\" and \"publication_keyword\" to retrieve additional information about the cited and citing publications.",
-        "author": "The \"author\" table is used to store information about authors. It contains a unique identifier for each author, a foreign key referencing the organization the author belongs to, the URL of the author's personal website, and the name of the author. This table can be joined with the \"organization\" table to retrieve additional information about the organization the author belongs to.",
-        "domain": "The \"domain\" table is used to store information about different domains. It has a unique identifier column called \"did\" and a column called \"name\" to store the name of the domain. This table can be joined with other tables such as \"cite\", \"author\", \"writes\", \"journal\", \"keyword\", \"conference\", \"publication\", \"organization\", \"domain_author\", \"domain_journal\", \"domain_keyword\", \"domain_conference\", \"domain_publication\", and \"publication_keyword\" to retrieve additional information related to the domains.",
-        "writes": "The \"writes\" table is used to establish a relationship between authors and publications. It contains foreign keys referencing the primary keys of the \"author\" and \"publication\" tables. This table can be joined with the \"author\" and \"publication\" tables to retrieve information about the authors who have written specific publications or the publications written by a particular author.",
-        "journal": "The \"journal\" table is used to store information about different journals. It has a unique identifier column called \"jid\" which is of type bigint. The table also includes a column called \"homepage\" which stores the homepage URL for the journal, and a column called \"name\" which stores the name of the journal.\n\nThis table can be joined with other tables such as \"cite\", \"author\", \"domain\", \"writes\", \"journal\", \"keyword\", \"conference\", \"publication\", \"organization\", \"domain_author\", \"domain_journal\", \"domain_keyword\", \"domain_conference\", \"domain_publication\", and \"publication_keyword\" to retrieve additional information related to journals.",
-        "keyword": "The \"keyword\" table is used to store unique identifiers and actual keywords. It can be joined with other tables such as \"cite\", \"author\", \"domain\", \"writes\", \"journal\", \"conference\", \"publication\", \"organization\", \"domain_author\", \"domain_journal\", \"domain_keyword\", \"domain_conference\", \"domain_publication\", and \"publication_keyword\" to associate keywords with various entities in the database.",
-        "conference": "The \"conference\" table is used to store information about conferences. It contains a unique identifier for each conference (cid), the homepage URL for the conference, and the name of the conference. This table can be joined with other tables such as \"cite\", \"author\", \"domain\", \"writes\", \"journal\", \"keyword\", \"publication\", \"organization\", \"domain_author\", \"domain_journal\", \"domain_keyword\", \"domain_conference\", \"domain_publication\", and \"publication_keyword\" to retrieve additional information related to conferences.",
-        "publication": "The \"publication\" table contains information about various publications. It includes columns such as \"year\" (representing the year of publication), \"cid\" (representing the ID of the conference where the publication was presented), \"citation_num\" (representing the number of citations received by the publication), \"jid\" (representing the ID of the journal where the publication was published), \"pid\" (representing the unique ID of the publication), \"reference_num\" (representing the number of references cited by the publication), \"title\" (representing the title of the publication), and \"abstract\" (representing the abstract of the publication).\n\nThis table can be joined with other tables such as \"cite\", \"author\", \"domain\", \"writes\", \"journal\", \"keyword\", \"conference\", \"organization\", \"domain_author\", \"domain_journal\", \"domain_keyword\", \"domain_conference\", \"domain_publication\", and \"publication_keyword\" to retrieve additional information related to the publications.",
-        "organization": "The \"organization\" table is used to store information about different organizations. It contains columns such as \"oid\" which is a unique identifier for each organization, \"continent\" which represents the continent where the organization is located, \"homepage\" which stores the URL of the organization's homepage, and \"name\" which holds the name of the organization.\n\nThis table can be joined with other tables such as \"cite\", \"author\", \"domain\", \"writes\", \"journal\", \"keyword\", \"conference\", \"publication\", \"domain_author\", \"domain_journal\", \"domain_keyword\", \"domain_conference\", \"domain_publication\", and \"publication_keyword\" to retrieve additional information related to organizations.",
-        "domain_author": "The \"domain_author\" table is used to establish a relationship between authors and domains in a database. It contains foreign key references to the \"author\" and \"domain\" tables, allowing for the association of authors with specific domains. This table can be joined with the \"author\" and \"domain\" tables to retrieve additional information about the authors and domains involved.",
-        "domain_journal": "The \"domain_journal\" table is used to establish a relationship between domains and journals. It contains foreign key references to the \"domain\" and \"journal\" tables, allowing for the association of a domain with a specific journal. This table can be joined with the \"domain\" and \"journal\" tables to retrieve additional information about the domains and journals involved.",
-        "domain_keyword": "The \"domain_keyword\" table is used to establish a relationship between domains and keywords. It contains foreign key references to the \"did\" column of the \"domain\" table and the \"kid\" column of the \"keyword\" table. This table can be joined with the \"domain\" and \"keyword\" tables to retrieve information about the domains and keywords associated with each other.",
-        "domain_conference": "The \"domain_conference\" table is used to establish a relationship between domains and conferences. It contains foreign key references to the \"cid\" column in the \"conference\" table and the \"did\" column in the \"domain\" table. This table can be joined with the \"conference\" and \"domain\" tables to retrieve information about the conferences associated with specific domains.",
-        "domain_publication": "The table \"domain_publication\" is used to establish a relationship between the \"domain\" and \"publication\" tables. It contains foreign key columns \"did\" and \"pid\" which reference the primary key columns of the \"domain\" and \"publication\" tables respectively. This table can be joined with the \"domain\" and \"publication\" tables to retrieve information about the domains and publications associated with each other.",
-        "publication_keyword": "The \"publication_keyword\" table is used to establish a relationship between publications and keywords. It contains foreign keys referencing the primary keys of the \"publication\" and \"keyword\" tables. This table can be joined with the \"publication\" and \"keyword\" tables to retrieve information about the keywords associated with each publication."
     }
 }

--- a/advising/advising.json
+++ b/advising/advising.json
@@ -1,608 +1,589 @@
 {
-    "status": "success",
     "table_metadata": {
         "gsi": [
             {
                 "data_type": "bigint",
                 "column_name": "course_offering_id",
-                "column_description": ["Unique identifier for a course offering"]
+                "column_description": "Unique identifier for a course offering"
             },
             {
                 "data_type": "bigint",
                 "column_name": "student_id",
-                "column_description": ["Unique identifier for a student enrolled in a course offering"]
+                "column_description": "Unique identifier for a student enrolled in a course offering"
             }
         ],
         "area": [
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["Unique identifier for each course"]
+                "column_description": "Unique identifier for each course"
             },
             {
                 "data_type": "text",
                 "column_name": "area",
-                "column_description": ["The area of study for each course"]
+                "column_description": "The area of study for each course"
             }
         ],
         "course": [
             {
                 "data_type": "bigint",
                 "column_name": "helpfulness_score",
-                "column_description": ["The overall helpfulness score of the course as rated by students."]
+                "column_description": "The overall helpfulness score of the course as rated by students."
             },
             {
                 "data_type": "bigint",
                 "column_name": "num_semesters",
-                "column_description": ["The number of semesters the course is offered in a year."]
+                "column_description": "The number of semesters the course is offered in a year."
             },
             {
                 "data_type": "bigint",
                 "column_name": "num_enrolled",
-                "column_description": ["The total number of students enrolled in the course."]
+                "column_description": "The total number of students enrolled in the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "num_reviews",
-                "column_description": ["The total number of reviews/ratings for the course."]
+                "column_description": "The total number of reviews/ratings for the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "clarity_score",
-                "column_description": ["The overall clarity score of the course as rated by students."]
+                "column_description": "The overall clarity score of the course as rated by students."
             },
             {
                 "data_type": "bigint",
                 "column_name": "easiness_score",
-                "column_description": ["The overall easiness score of the course as rated by students."]
+                "column_description": "The overall easiness score of the course as rated by students."
             },
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["The unique identifier for the course."]
+                "column_description": "The unique identifier for the course."
             },
             {
                 "data_type": "text",
                 "column_name": "description",
-                "column_description": ["A brief description of the course content."]
+                "column_description": "A brief description of the course content."
             },
             {
                 "data_type": "boolean",
                 "column_name": "has_projects",
-                "column_description": ["Indicates whether the course has any projects or not."]
+                "column_description": "Indicates whether the course has any projects or not."
             },
             {
                 "data_type": "boolean",
                 "column_name": "has_exams",
-                "column_description": ["Indicates whether the course has any exams or not."]
+                "column_description": "Indicates whether the course has any exams or not."
             },
             {
                 "data_type": "boolean",
                 "column_name": "has_discussion",
-                "column_description": ["Indicates whether the course has any discussion sessions or not."]
+                "column_description": "Indicates whether the course has any discussion sessions or not."
             },
             {
                 "data_type": "boolean",
                 "column_name": "has_lab",
-                "column_description": ["Indicates whether the course has any lab sessions or not."]
+                "column_description": "Indicates whether the course has any lab sessions or not."
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["The name of the course."]
+                "column_description": "The name of the course."
             },
             {
                 "data_type": "text",
                 "column_name": "department",
-                "column_description": ["The department offering the course."]
+                "column_description": "The department offering the course."
             },
             {
                 "data_type": "text",
                 "column_name": "number",
-                "column_description": ["The course number/code."]
+                "column_description": "The course number/code."
             },
             {
                 "data_type": "text",
                 "column_name": "credits",
-                "column_description": ["The number of credits awarded for completing the course."]
+                "column_description": "The number of credits awarded for completing the course."
             },
             {
                 "data_type": "text",
                 "column_name": "advisory_requirement",
-                "column_description": ["Any advisory requirements for taking the course."]
+                "column_description": "Any advisory requirements for taking the course."
             },
             {
                 "data_type": "text",
                 "column_name": "enforced_requirement",
-                "column_description": ["Any enforced requirements for taking the course."]
+                "column_description": "Any enforced requirements for taking the course."
             }
         ],
         "program": [
             {
                 "data_type": "bigint",
                 "column_name": "program_id",
-                "column_description": ["Unique identifier for each program"]
+                "column_description": "Unique identifier for each program"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["Name of the program"]
+                "column_description": "Name of the program"
             },
             {
                 "data_type": "text",
                 "column_name": "college",
-                "column_description": ["Name of the college offering the program"]
+                "column_description": "Name of the college offering the program"
             },
             {
                 "data_type": "text",
                 "column_name": "introduction",
-                "column_description": ["Introduction to the program"]
+                "column_description": "Introduction to the program"
             }
         ],
         "student": [
             {
                 "data_type": "bigint",
                 "column_name": "student_id",
-                "column_description": ["Unique identifier for each student"]
+                "column_description": "Unique identifier for each student"
             },
             {
                 "data_type": "bigint",
                 "column_name": "program_id",
-                "column_description": ["Identifier for the program the student is enrolled in"]
+                "column_description": "Identifier for the program the student is enrolled in"
             },
             {
                 "data_type": "bigint",
                 "column_name": "total_credit",
-                "column_description": ["Total number of credits earned by the student"]
+                "column_description": "Total number of credits earned by the student"
             },
             {
                 "data_type": "numeric",
                 "column_name": "total_gpa",
-                "column_description": ["Cumulative GPA of the student"]
+                "column_description": "Cumulative GPA of the student"
             },
             {
                 "data_type": "date",
                 "column_name": "admit_term",
-                "column_description": ["Term in which the student was admitted. Format is YYYY-MM-DD"]
+                "column_description": "Term in which the student was admitted. Format is YYYY-MM-DD"
             },
             {
                 "data_type": "date",
                 "column_name": "predicted_graduation_semester",
-                "column_description": ["Semester in which the student is predicted to graduate. Format is YYYY-MM-DD"]
+                "column_description": "Semester in which the student is predicted to graduate. Format is YYYY-MM-DD"
             },
             {
                 "data_type": "text",
                 "column_name": "degree",
-                "column_description": ["Degree program the student is enrolled in"]
+                "column_description": "Degree program the student is enrolled in"
             },
             {
                 "data_type": "text",
                 "column_name": "entered_as",
-                "column_description": ["Status of the student when they entered the program"]
+                "column_description": "Status of the student when they entered the program"
             },
             {
                 "data_type": "text",
                 "column_name": "lastname",
-                "column_description": ["Last name of the student"]
+                "column_description": "Last name of the student"
             },
             {
                 "data_type": "text",
                 "column_name": "firstname",
-                "column_description": ["First name of the student"]
+                "column_description": "First name of the student"
             },
             {
                 "data_type": "text",
                 "column_name": "minor",
-                "column_description": ["Minor program the student is enrolled in"]
+                "column_description": "Minor program the student is enrolled in"
             },
             {
                 "data_type": "text",
                 "column_name": "declare_major",
-                "column_description": ["Major program the student declared"]
+                "column_description": "Major program the student declared"
             },
             {
                 "data_type": "text",
                 "column_name": "internship",
-                "column_description": ["Internship program the student is enrolled in"]
+                "column_description": "Internship program the student is enrolled in"
             }
         ],
         "semester": [
             {
                 "data_type": "bigint",
                 "column_name": "semester_id",
-                "column_description": ["Unique identifier for each semester"]
+                "column_description": "Unique identifier for each semester"
             },
             {
                 "data_type": "bigint",
                 "column_name": "year",
-                "column_description": ["The year in which the semester takes place"]
+                "column_description": "The year in which the semester takes place"
             },
             {
                 "data_type": "text",
                 "column_name": "semester",
-                "column_description": ["The name or identifier for the semester (e.g. Fall, Spring, Summer)"]
+                "column_description": "The name or identifier for the semester (e.g. Fall, Spring, Summer)"
             }
         ],
         "instructor": [
             {
                 "data_type": "bigint",
                 "column_name": "instructor_id",
-                "column_description": ["Unique identifier for each instructor"]
+                "column_description": "Unique identifier for each instructor"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["Name of the instructor"]
+                "column_description": "Name of the instructor"
             },
             {
                 "data_type": "text",
                 "column_name": "uniqname",
-                "column_description": ["Unique name of the instructor used for login and identification purposes"]
+                "column_description": "Unique name of the instructor used for login and identification purposes"
             }
         ],
         "program_course": [
             {
                 "data_type": "bigint",
                 "column_name": "program_id",
-                "column_description": ["The ID of the program associated with the course"]
+                "column_description": "The ID of the program associated with the course"
             },
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["The ID of the course"]
+                "column_description": "The ID of the course"
             },
             {
                 "data_type": "bigint",
                 "column_name": "workload",
-                "column_description": ["The workload of the course in hours"]
+                "column_description": "The workload of the course in hours"
             },
             {
                 "data_type": "text",
                 "column_name": "category",
-                "column_description": ["The category of the course"]
+                "column_description": "The category of the course"
             }
         ],
         "student_record": [
             {
                 "data_type": "bigint",
                 "column_name": "student_id",
-                "column_description": ["Unique identifier for each student"]
+                "column_description": "Unique identifier for each student"
             },
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["Unique identifier for each course"]
+                "column_description": "Unique identifier for each course"
             },
             {
                 "data_type": "bigint",
                 "column_name": "semester",
-                "column_description": ["The semester ID in which the course was taken"]
+                "column_description": "The semester ID in which the course was taken"
             },
             {
                 "data_type": "bigint",
                 "column_name": "offering_id",
-                "column_description": ["Unique identifier for each offering of a course"]
+                "column_description": "Unique identifier for each offering of a course"
             },
             {
                 "data_type": "text",
                 "column_name": "how",
-                "column_description": ["How the student took the course (e.g. in-person, online)"]
+                "column_description": "How the student took the course (e.g. in-person, online)"
             },
             {
                 "data_type": "text",
                 "column_name": "transfer_source",
-                "column_description": ["If the course was transferred from another institution, the name of that institution"]
+                "column_description": "If the course was transferred from another institution, the name of that institution"
             },
             {
                 "data_type": "text",
                 "column_name": "earn_credit",
-                "column_description": ["Whether the student earned credit for the course (e.g. Yes, No)"]
+                "column_description": "Whether the student earned credit for the course (e.g. Yes, No)"
             },
             {
                 "data_type": "text",
                 "column_name": "repeat_term",
-                "column_description": ["If the student repeated the course, the semester in which it was repeated"]
+                "column_description": "If the student repeated the course, the semester in which it was repeated"
             },
             {
                 "data_type": "text",
                 "column_name": "test_id",
-                "column_description": ["Unique identifier for each test taken in the course"]
+                "column_description": "Unique identifier for each test taken in the course"
             },
             {
                 "data_type": "text",
                 "column_name": "grade",
-                "column_description": ["The grade received for the course"]
+                "column_description": "The grade received for the course"
             }
         ],
         "course_offering": [
             {
                 "data_type": "bigint",
                 "column_name": "offering_id",
-                "column_description": ["Unique identifier for each course offering"]
+                "column_description": "Unique identifier for each course offering"
             },
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["Unique identifier for each course"]
+                "column_description": "Unique identifier for each course"
             },
             {
                 "data_type": "bigint",
                 "column_name": "semester",
-                "column_description": ["The semester ID in which the course is offered"]
+                "column_description": "The semester ID in which the course is offered"
             },
             {
                 "data_type": "bigint",
                 "column_name": "section_number",
-                "column_description": ["The section number of the course"]
+                "column_description": "The section number of the course"
             },
             {
                 "data_type": "time without time zone",
                 "column_name": "start_time",
-                "column_description": ["The start time of the course"]
+                "column_description": "The start time of the course"
             },
             {
                 "data_type": "time without time zone",
                 "column_name": "end_time",
-                "column_description": ["The end time of the course"]
+                "column_description": "The end time of the course"
             },
             {
                 "data_type": "text",
                 "column_name": "monday",
-                "column_description": ["The instructor's name for Monday"]
+                "column_description": "The instructor's name for Monday"
             },
             {
                 "data_type": "text",
                 "column_name": "tuesday",
-                "column_description": ["The instructor's name for Tuesday"]
+                "column_description": "The instructor's name for Tuesday"
             },
             {
                 "data_type": "text",
                 "column_name": "wednesday",
-                "column_description": ["The instructor's name for Wednesday"]
+                "column_description": "The instructor's name for Wednesday"
             },
             {
                 "data_type": "text",
                 "column_name": "thursday",
-                "column_description": ["The instructor's name for Thursday"]
+                "column_description": "The instructor's name for Thursday"
             },
             {
                 "data_type": "text",
                 "column_name": "friday",
-                "column_description": ["The instructor's name for Friday"]
+                "column_description": "The instructor's name for Friday"
             },
             {
                 "data_type": "text",
                 "column_name": "saturday",
-                "column_description": ["The instructor's name for Saturday"]
+                "column_description": "The instructor's name for Saturday"
             },
             {
                 "data_type": "text",
                 "column_name": "sunday",
-                "column_description": ["The instructor's name for Sunday"]
+                "column_description": "The instructor's name for Sunday"
             },
             {
                 "data_type": "boolean",
                 "column_name": "has_final_project",
-                "column_description": ["Indicates whether the course has a final project"]
+                "column_description": "Indicates whether the course has a final project"
             },
             {
                 "data_type": "boolean",
                 "column_name": "has_final_exam",
-                "column_description": ["Indicates whether the course has a final exam"]
+                "column_description": "Indicates whether the course has a final exam"
             },
             {
                 "data_type": "text",
                 "column_name": "textbook",
-                "column_description": ["The name of the textbook used in the course"]
+                "column_description": "The name of the textbook used in the course"
             },
             {
                 "data_type": "text",
                 "column_name": "class_address",
-                "column_description": ["The address of the classroom where the course is held"]
+                "column_description": "The address of the classroom where the course is held"
             },
             {
                 "data_type": "text",
                 "column_name": "allow_audit",
-                "column_description": ["Indicates whether auditing the course is allowed"]
+                "column_description": "Indicates whether auditing the course is allowed"
             }
         ],
         "course_tags_count": [
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["The unique identifier for each course."]
+                "column_description": "The unique identifier for each course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "clear_grading",
-                "column_description": ["Number of students who found the grading criteria clear and easy to understand."]
+                "column_description": "Number of students who found the grading criteria clear and easy to understand."
             },
             {
                 "data_type": "bigint",
                 "column_name": "pop_quiz",
-                "column_description": ["Number of pop quizzes given during the course."]
+                "column_description": "Number of pop quizzes given during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "group_projects",
-                "column_description": ["Number of group projects assigned during the course."]
+                "column_description": "Number of group projects assigned during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "inspirational",
-                "column_description": ["Number of students who found the course content inspirational."]
+                "column_description": "Number of students who found the course content inspirational."
             },
             {
                 "data_type": "bigint",
                 "column_name": "long_lectures",
-                "column_description": ["Number of students who found the lectures to be too long."]
+                "column_description": "Number of students who found the lectures to be too long."
             },
             {
                 "data_type": "bigint",
                 "column_name": "extra_credit",
-                "column_description": ["Number of extra credit opportunities provided during the course."]
+                "column_description": "Number of extra credit opportunities provided during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "few_tests",
-                "column_description": ["Number of tests given during the course."]
+                "column_description": "Number of tests given during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "good_feedback",
-                "column_description": ["Number of students who received good feedback from the instructor."]
+                "column_description": "Number of students who received good feedback from the instructor."
             },
             {
                 "data_type": "bigint",
                 "column_name": "tough_tests",
-                "column_description": ["Number of students who found the tests to be tough."]
+                "column_description": "Number of students who found the tests to be tough."
             },
             {
                 "data_type": "bigint",
                 "column_name": "heavy_papers",
-                "column_description": ["Number of papers assigned during the course."]
+                "column_description": "Number of papers assigned during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "cares_for_students",
-                "column_description": ["Number of students who felt that the instructor cared for their well-being."]
+                "column_description": "Number of students who felt that the instructor cared for their well-being."
             },
             {
                 "data_type": "bigint",
                 "column_name": "heavy_assignments",
-                "column_description": ["Number of assignments given during the course."]
+                "column_description": "Number of assignments given during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "respected",
-                "column_description": ["Number of students who respected the instructor."]
+                "column_description": "Number of students who respected the instructor."
             },
             {
                 "data_type": "bigint",
                 "column_name": "participation",
-                "column_description": ["Number of students who participated actively in the course."]
+                "column_description": "Number of students who participated actively in the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "heavy_reading",
-                "column_description": ["Number of reading assignments given during the course."]
+                "column_description": "Number of reading assignments given during the course."
             },
             {
                 "data_type": "bigint",
                 "column_name": "tough_grader",
-                "column_description": ["Number of students who found the instructor to be a tough grader."]
+                "column_description": "Number of students who found the instructor to be a tough grader."
             },
             {
                 "data_type": "bigint",
                 "column_name": "hilarious",
-                "column_description": ["Number of students who found the instructor to be hilarious."]
+                "column_description": "Number of students who found the instructor to be hilarious."
             },
             {
                 "data_type": "bigint",
                 "column_name": "would_take_again",
-                "column_description": ["Number of students who would take the course again."]
+                "column_description": "Number of students who would take the course again."
             },
             {
                 "data_type": "bigint",
                 "column_name": "good_lecture",
-                "column_description": ["Number of students who found the lectures to be good."]
+                "column_description": "Number of students who found the lectures to be good."
             },
             {
                 "data_type": "bigint",
                 "column_name": "no_skip",
-                "column_description": ["Number of students who did not skip any classes during the course."]
+                "column_description": "Number of students who did not skip any classes during the course."
             }
         ],
         "comment_instructor": [
             {
                 "data_type": "bigint",
                 "column_name": "instructor_id",
-                "column_description": ["Unique identifier for the instructor"]
+                "column_description": "Unique identifier for the instructor"
             },
             {
                 "data_type": "bigint",
                 "column_name": "student_id",
-                "column_description": ["Unique identifier for the student"]
+                "column_description": "Unique identifier for the student"
             },
             {
                 "data_type": "bigint",
                 "column_name": "score",
-                "column_description": ["Score given by the student to the instructor"]
+                "column_description": "Score given by the student to the instructor"
             },
             {
                 "data_type": "text",
                 "column_name": "comment_text",
-                "column_description": ["Textual comment given by the student about the instructor"]
+                "column_description": "Textual comment given by the student about the instructor"
             }
         ],
         "course_prerequisite": [
             {
                 "data_type": "bigint",
                 "column_name": "pre_course_id",
-                "column_description": ["The ID of the prerequisite course"]
+                "column_description": "The ID of the prerequisite course"
             },
             {
                 "data_type": "bigint",
                 "column_name": "course_id",
-                "column_description": ["The ID of the course that has the prerequisite"]
+                "column_description": "The ID of the course that has the prerequisite"
             }
         ],
         "offering_instructor": [
             {
                 "data_type": "bigint",
                 "column_name": "offering_instructor_id",
-                "column_description": ["Unique identifier for each offering-instructor pair"]
+                "column_description": "Unique identifier for each offering-instructor pair"
             },
             {
                 "data_type": "bigint",
                 "column_name": "offering_id",
-                "column_description": ["Foreign key referencing the offering table"]
+                "column_description": "Foreign key referencing the offering table"
             },
             {
                 "data_type": "bigint",
                 "column_name": "instructor_id",
-                "column_description": ["Foreign key referencing the instructor table"]
+                "column_description": "Foreign key referencing the instructor table"
             }
         ],
         "program_requirement": [
             {
                 "data_type": "bigint",
                 "column_name": "program_id",
-                "column_description": ["Unique identifier for a program"]
+                "column_description": "Unique identifier for a program"
             },
             {
                 "data_type": "bigint",
                 "column_name": "min_credit",
-                "column_description": ["Minimum number of credits required for the program"]
+                "column_description": "Minimum number of credits required for the program"
             },
             {
                 "data_type": "text",
                 "column_name": "category",
-                "column_description": ["Category of the program"]
+                "column_description": "Category of the program"
             },
             {
                 "data_type": "text",
                 "column_name": "additional_req",
-                "column_description": ["Additional requirements for the program, if any"]
+                "column_description": "Additional requirements for the program, if any"
             }
         ]
-    },
-    "glossary": "The comment_instructor table is a subset of offering_instructor table.",
-    "table_descriptions": {
-        "gsi": "The \"gsi\" table is used to store information about the enrollment of students in course offerings. It contains the unique identifiers for both the course offering and the student. This table can be joined with other tables such as \"course_offering\" and \"student\" to retrieve additional information about the course offerings and students involved in the enrollment process.",
-        "area": "The \"area\" table is used to store information about the area of study for each course. It has two columns: \"course_id\" which is a unique identifier for each course, and \"area\" which represents the area of study for that course. This table can be joined with the \"course\" table to get additional information about each course.",
-        "course": "The \"course\" table contains information about different courses offered by a department. It includes details such as the course's helpfulness score, clarity score, easiness score, number of semesters offered, number of students enrolled, number of reviews, course description, whether it has projects, exams, discussion sessions, or lab sessions, the course name, department, number/code, credits awarded, and any advisory or enforced requirements for taking the course.\n\nThis table can be joined with the following tables: \"gsi\", \"area\", \"program\", \"student\", \"semester\", \"instructor\", \"program_course\", \"student_record\", \"course_offering\", \"course_tags_count\", \"comment_instructor\", \"course_prerequisite\", \"offering_instructor\", and \"program_requirement\".",
-        "program": "The \"program\" table is used to store information about different academic programs offered by colleges. It contains columns such as \"program_id\" (a unique identifier for each program), \"name\" (the name of the program), \"college\" (the name of the college offering the program), and \"introduction\" (an introduction to the program). This table can be joined with other tables such as \"gsi\", \"area\", \"course\", \"student\", \"semester\", \"instructor\", \"program_course\", \"student_record\", \"course_offering\", \"course_tags_count\", \"comment_instructor\", \"course_prerequisite\", \"offering_instructor\", and \"program_requirement\" to retrieve additional information related to the programs.",
-        "student": "The \"student\" table is used to store information about students. It contains columns such as student_id, program_id, total_credit, total_gpa, admit_term, predicted_graduation_semester, degree, entered_as, lastname, firstname, minor, declare_major, and internship. This table can be joined with other tables such as \"gsi\", \"area\", \"course\", \"program\", \"semester\", \"instructor\", \"program_course\", \"student_record\", \"course_offering\", \"course_tags_count\", \"comment_instructor\", \"course_prerequisite\", \"offering_instructor\", and \"program_requirement\" to retrieve additional information about the students.",
-        "semester": "The \"semester\" table is used to store information about different semesters. It has columns for the unique identifier of each semester, the year in which the semester takes place, and the name or identifier for the semester (e.g., Fall, Spring, Summer). This table can be joined with other tables such as \"gsi\", \"area\", \"course\", \"program\", \"student\", \"instructor\", \"program_course\", \"student_record\", \"course_offering\", \"course_tags_count\", \"comment_instructor\", \"course_prerequisite\", \"offering_instructor\", and \"program_requirement\" to retrieve additional information related to specific semesters.",
-        "instructor": "The \"instructor\" table is used to store information about instructors. It contains columns such as \"instructor_id\" which is a unique identifier for each instructor, \"name\" which represents the name of the instructor, and \"uniqname\" which is a unique name used for login and identification purposes. This table can be joined with other tables such as \"course_offering\" or \"offering_instructor\" to retrieve information about the courses taught by each instructor.",
-        "program_course": "The \"program_course\" table is used to store the relationship between programs and courses. It contains the program ID and course ID columns, which represent the IDs of the program and course associated with each entry. Additionally, it includes the workload column, which represents the workload of the course in hours, and the category column, which represents the category of the course. This table can be joined with the \"program\" and \"course\" tables to retrieve additional information about the programs and courses.",
-        "student_record": "The \"student_record\" table contains information about the courses taken by students. It includes columns such as student_id, course_id, semester, offering_id, how, transfer_source, earn_credit, repeat_term, test_id, and grade. This table can be joined with other tables such as \"student\", \"course\", \"semester\", \"course_offering\", and \"instructor\" to gather additional information about the students, courses, semesters, and instructors associated with the student records.",
-        "course_offering": "The \"course_offering\" table is used to store information about the different offerings of courses. It contains columns such as \"offering_id\" and \"course_id\" which serve as unique identifiers for each course offering and course respectively. Other columns include \"semester\" which indicates the semester in which the course is offered, \"section_number\" which represents the section number of the course, and \"start_time\" and \"end_time\" which specify the start and end times of the course. The table also includes columns for the instructor's name for each day of the week, allowing for tracking of the instructor's schedule. Additional columns indicate whether the course has a final project or exam, the name of the textbook used, the address of the classroom, and whether auditing the course is allowed. \n\nThis table can be joined with the \"course\" table to retrieve information about the course itself, such as its title and description. It can also be joined with the \"semester\" table to obtain details about the specific semester in which the course is offered.",
-        "course_tags_count": "The \"course_tags_count\" table provides counts for various attributes related to a course. It includes information such as the number of students who found the grading criteria clear, the number of pop quizzes given, the number of group projects assigned, the number of students who found the course content inspirational, and more. This table can be joined with other tables such as \"course\", \"program\", \"student\", \"semester\", \"instructor\", and others to analyze and compare course attributes and student feedback.",
-        "comment_instructor": "The \"comment_instructor\" table is used to store comments and scores given by students about instructors. It has columns for the unique identifiers of the instructor and the student, as well as a score and a textual comment. This table can be joined with other tables such as \"instructor\" and \"student\" to retrieve additional information about the instructors and students involved in the comments.",
-        "course_prerequisite": "The table \"course_prerequisite\" is used to store information about the prerequisites for a course. It contains two columns: \"pre_course_id\" which represents the ID of the prerequisite course, and \"course_id\" which represents the ID of the course that has the prerequisite. This table can be joined with the \"course\" table to retrieve additional information about the courses and their prerequisites.",
-        "offering_instructor": "The \"offering_instructor\" table is used to store information about the relationship between course offerings and instructors. It contains a unique identifier for each offering-instructor pair, as well as foreign keys referencing the offering and instructor tables. This table can be joined with the \"offering\" and \"instructor\" tables to retrieve additional information about the course offerings and instructors involved.",
-        "program_requirement": "The \"program_requirement\" table is used to store information about the requirements for a program. It contains columns such as \"program_id\" which is a unique identifier for a program, \"min_credit\" which represents the minimum number of credits required for the program, \"category\" which indicates the category of the program, and \"additional_req\" which specifies any additional requirements for the program, if applicable.\n\nThis table can be joined with other tables such as \"program\" to retrieve additional details about the program, or with \"course\" to determine if specific courses are required for the program."
     }
 }

--- a/atis/atis.json
+++ b/atis/atis.json
@@ -4,711 +4,684 @@
             {
                 "data_type": "text",
                 "column_name": "city_code",
-                "column_description": ["The code assigned to the city"]
+                "column_description": "The code assigned to the city"
             },
             {
                 "data_type": "text",
                 "column_name": "city_name",
-                "column_description": ["The name of the city"]
+                "column_description": "The name of the city"
             },
             {
                 "data_type": "text",
                 "column_name": "state_code",
-                "column_description": ["The code assigned to the state where the city is located"]
+                "column_description": "The code assigned to the state where the city is located"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country where the city is located"]
+                "column_description": "The name of the country where the city is located"
             },
             {
                 "data_type": "text",
                 "column_name": "time_zone_code",
-                "column_description": ["The code assigned to the time zone where the city is located. Either 'EST', 'CST', 'MST', or 'PST'."]
+                "column_description": "The code assigned to the time zone where the city is located. Either 'EST', 'CST', 'MST', or 'PST'."
             }
         ],
         "days": [
             {
                 "data_type": "text",
                 "column_name": "days_code",
-                "column_description": ["A code representing a day of the week"]
+                "column_description": "A code representing a day of the week"
             },
             {
                 "data_type": "text",
                 "column_name": "day_name",
-                "column_description": ["The name of a day of the week"]
+                "column_description": "The name of a day of the week"
             }
         ],
         "fare": [
             {
                 "data_type": "bigint",
                 "column_name": "one_direction_cost",
-                "column_description": ["The cost of a one-way trip for this fare"]
+                "column_description": "The cost of a one-way trip for this fare"
             },
             {
                 "data_type": "bigint",
                 "column_name": "round_trip_cost",
-                "column_description": ["The cost of a round-trip for this fare"]
+                "column_description": "The cost of a round-trip for this fare"
             },
             {
                 "data_type": "bigint",
                 "column_name": "fare_id",
-                "column_description": ["The unique identifier for this fare"]
+                "column_description": "The unique identifier for this fare"
             },
             {
                 "data_type": "text",
                 "column_name": "fare_basis_code",
-                "column_description": ["The code used to determine the fare's pricing rules"]
+                "column_description": "The code used to determine the fare's pricing rules"
             },
             {
                 "data_type": "text",
                 "column_name": "fare_airline",
-                "column_description": ["The airline code associated with this fare"]
+                "column_description": "The airline code associated with this fare"
             },
             {
                 "data_type": "text",
                 "column_name": "restriction_code",
-                "column_description": ["Any restrictions or limitations associated with this fare"]
+                "column_description": "Any restrictions or limitations associated with this fare"
             },
             {
                 "data_type": "text",
                 "column_name": "round_trip_required",
-                "column_description": ["Indicates whether a round-trip is required to purchase this fare. Either Yes or No."]
+                "column_description": "Indicates whether a round-trip is required to purchase this fare. Either Yes or No."
             },
             {
                 "data_type": "text",
                 "column_name": "from_airport",
-                "column_description": ["The 3-letter airport code for the departure location"]
+                "column_description": "The 3-letter airport code for the departure location"
             },
             {
                 "data_type": "text",
                 "column_name": "to_airport",
-                "column_description": ["The 3-letter airport code for the arrival location"]
+                "column_description": "The 3-letter airport code for the arrival location"
             }
         ],
         "month": [
             {
                 "data_type": "bigint",
                 "column_name": "month_number",
-                "column_description": ["A unique number assigned to each month of the year."]
+                "column_description": "A unique number assigned to each month of the year."
             },
             {
                 "data_type": "text",
                 "column_name": "month_name",
-                "column_description": ["The name of the month, e.g. January, February, etc."]
+                "column_description": "The name of the month, e.g. January, February, etc."
             }
         ],
         "state": [
             {
                 "data_type": "text",
                 "column_name": "state_code",
-                "column_description": ["The code representing the state"]
+                "column_description": "The code representing the state"
             },
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state"]
+                "column_description": "The name of the state"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country the state belongs to"]
+                "column_description": "The name of the country the state belongs to"
             }
         ],
         "flight": [
             {
                 "data_type": "bigint",
                 "column_name": "flight_id",
-                "column_description": ["Unique identifier for each flight"]
+                "column_description": "Unique identifier for each flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "departure_time",
-                "column_description": ["Epoch timestamp for departure time. This is in Unix timestamp format. Always convert to regular date time format."]
+                "column_description": "Epoch timestamp for departure time. This is in Unix timestamp format. Always convert to regular date time format."
             },
             {
                 "data_type": "bigint",
                 "column_name": "arrival_time",
-                "column_description": ["Epoch timestamp for arrival time. This is in Unix timestamp format. Always convert to regular date time format."]
+                "column_description": "Epoch timestamp for arrival time. This is in Unix timestamp format. Always convert to regular date time format."
             },
             {
                 "data_type": "text",
                 "column_name": "flight_number",
-                "column_description": ["Flight number assigned by the airline"]
+                "column_description": "Flight number assigned by the airline"
             },
             {
                 "data_type": "bigint",
                 "column_name": "stops",
-                "column_description": ["Number of stops during the flight"]
+                "column_description": "Number of stops during the flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "connections",
-                "column_description": ["Number of connections during the flight"]
+                "column_description": "Number of connections during the flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "time_elapsed",
-                "column_description": ["Total time elapsed during the flight in seconds"]
+                "column_description": "Total time elapsed during the flight in seconds"
             },
             {
                 "data_type": "text",
                 "column_name": "airline_code",
-                "column_description": ["Code assigned to the airline"]
+                "column_description": "Code assigned to the airline"
             },
             {
                 "data_type": "text",
                 "column_name": "dual_carrier",
-                "column_description": ["Code assigned to the dual carrier"]
+                "column_description": "Code assigned to the dual carrier"
             },
             {
                 "data_type": "text",
                 "column_name": "flight_days",
-                "column_description": ["Days of the week the flight operates on. comma-delimited 3-letter abbreviation, eg `mon,tue,wed`"]
+                "column_description": "Days of the week the flight operates on. comma-delimited 3-letter abbreviation, eg `mon,tue,wed`"
             },
             {
                 "data_type": "text",
                 "column_name": "from_airport",
-                "column_description": ["Code assigned to the departure airport"]
+                "column_description": "Code assigned to the departure airport"
             },
             {
                 "data_type": "text",
                 "column_name": "to_airport",
-                "column_description": ["Code assigned to the arrival airport"]
+                "column_description": "Code assigned to the arrival airport"
             },
             {
                 "data_type": "text",
                 "column_name": "aircraft_code_sequence",
-                "column_description": ["Code assigned to the aircraft"]
+                "column_description": "Code assigned to the aircraft"
             },
             {
                 "data_type": "text",
                 "column_name": "meal_code",
-                "column_description": ["Code assigned to the meal provided during the flight"]
+                "column_description": "Code assigned to the meal provided during the flight"
             },
             {
                 "data_type": "text",
                 "column_name": "airline_flight",
-                "column_description": ["Code assigned to the airline flight"]
+                "column_description": "Code assigned to the airline flight"
             }
         ],
         "airline": [
             {
                 "data_type": "text",
                 "column_name": "airline_code",
-                "column_description": ["The code assigned to the airline"]
+                "column_description": "The code assigned to the airline"
             },
             {
                 "data_type": "text",
                 "column_name": "airline_name",
-                "column_description": ["The name of the airline"]
+                "column_description": "The name of the airline"
             },
             {
                 "data_type": "text",
                 "column_name": "note",
-                "column_description": ["Any additional notes or comments about the airline"]
+                "column_description": "Any additional notes or comments about the airline"
             }
         ],
         "airport": [
             {
                 "data_type": "bigint",
                 "column_name": "minimum_connect_time",
-                "column_description": ["The minimum amount of time required for a connecting flight at the airport. This is in minutes."]
+                "column_description": "The minimum amount of time required for a connecting flight at the airport."
             },
             {
                 "data_type": "text",
                 "column_name": "airport_name",
-                "column_description": ["The name of the airport."]
+                "column_description": "The name of the airport."
             },
             {
                 "data_type": "text",
                 "column_name": "airport_location",
-                "column_description": ["The location of the airport."]
+                "column_description": "The location of the airport."
             },
             {
                 "data_type": "text",
                 "column_name": "airport_code",
-                "column_description": ["The code assigned to the airport."]
+                "column_description": "The code assigned to the airport."
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country where the airport is located."]
+                "column_description": "The name of the country where the airport is located."
             },
             {
                 "data_type": "text",
                 "column_name": "time_zone_code",
-                "column_description": ["The code assigned to the time zone where the airport is located. Either 'EST', 'CST', 'MST', or 'PST'."]
+                "column_description": "The code assigned to the time zone where the airport is located."
             },
             {
                 "data_type": "text",
                 "column_name": "state_code",
-                "column_description": ["The code assigned to the state where the airport is located."]
+                "column_description": "The code assigned to the state where the airport is located."
             }
         ],
         "aircraft": [
             {
                 "data_type": "bigint",
                 "column_name": "length",
-                "column_description": ["The length of the aircraft in feet."]
+                "column_description": "The length of the aircraft in feet."
             },
             {
                 "data_type": "bigint",
                 "column_name": "weight",
-                "column_description": ["The weight of the aircraft in pounds."]
+                "column_description": "The weight of the aircraft in pounds."
             },
             {
                 "data_type": "bigint",
                 "column_name": "capacity",
-                "column_description": ["The maximum number of passengers the aircraft can carry."]
+                "column_description": "The maximum number of passengers the aircraft can carry."
             },
             {
                 "data_type": "bigint",
                 "column_name": "pay_load",
-                "column_description": ["The maximum weight of cargo the aircraft can carry."]
+                "column_description": "The maximum weight of cargo the aircraft can carry."
             },
             {
                 "data_type": "bigint",
                 "column_name": "cruising_speed",
-                "column_description": ["The speed at which the aircraft cruises in miles per hour."]
+                "column_description": "The speed at which the aircraft cruises in miles per hour."
             },
             {
                 "data_type": "bigint",
                 "column_name": "range_miles",
-                "column_description": ["The maximum distance the aircraft can fly in miles."]
+                "column_description": "The maximum distance the aircraft can fly in miles."
             },
             {
                 "data_type": "bigint",
                 "column_name": "engines",
-                "column_description": ["The number of engines the aircraft has."]
+                "column_description": "The number of engines the aircraft has."
             },
             {
                 "data_type": "bigint",
                 "column_name": "wing_span",
-                "column_description": ["The distance between the tips of the aircraft's wings in feet."]
+                "column_description": "The distance between the tips of the aircraft's wings in feet."
             },
             {
                 "data_type": "text",
                 "column_name": "pressurized",
-                "column_description": ["Indicates whether the aircraft is pressurized or not. Possible values are 'Yes' and 'No'."]
+                "column_description": "Indicates whether the aircraft is pressurized or not. Possible values are 'Yes' and 'No'."
             },
             {
                 "data_type": "text",
                 "column_name": "aircraft_description",
-                "column_description": ["A short description of the aircraft."]
+                "column_description": "A short description of the aircraft."
             },
             {
                 "data_type": "text",
                 "column_name": "manufacturer",
-                "column_description": ["The name of the manufacturer of the aircraft."]
+                "column_description": "The name of the manufacturer of the aircraft."
             },
             {
                 "data_type": "text",
                 "column_name": "basic_type",
-                "column_description": ["The basic type of the aircraft."]
+                "column_description": "The basic type of the aircraft."
             },
             {
                 "data_type": "text",
                 "column_name": "propulsion",
-                "column_description": ["The type of propulsion used by the aircraft."]
+                "column_description": "The type of propulsion used by the aircraft."
             },
             {
                 "data_type": "text",
                 "column_name": "wide_body",
-                "column_description": ["Indicates whether the aircraft is a wide body or not. Possible values are 'Yes' and 'No'."]
+                "column_description": "Indicates whether the aircraft is a wide body or not. Possible values are 'Yes' and 'No'."
             },
             {
                 "data_type": "text",
                 "column_name": "aircraft_code",
-                "column_description": ["The code assigned to the aircraft by the International Air Transport Association (IATA)."]
+                "column_description": "The code assigned to the aircraft by the International Air Transport Association (IATA)."
             }
         ],
         "time_zone": [
             {
                 "data_type": "bigint",
                 "column_name": "hours_from_gmt",
-                "column_description": ["The number of hours that the time zone is ahead or behind Greenwich Mean Time (GMT)"]
+                "column_description": "The number of hours that the time zone is ahead or behind Greenwich Mean Time (GMT)"
             },
             {
                 "data_type": "text",
                 "column_name": "time_zone_code",
-                "column_description": ["A short code that represents the time zone"]
+                "column_description": "A short code that represents the time zone"
             },
             {
                 "data_type": "text",
                 "column_name": "time_zone_name",
-                "column_description": ["The name of the time zone"]
+                "column_description": "The name of the time zone"
             }
         ],
         "fare_basis": [
             {
                 "data_type": "text",
                 "column_name": "fare_basis_code",
-                "column_description": ["The code that identifies the fare basis"]
+                "column_description": "The code that identifies the fare basis"
             },
             {
                 "data_type": "text",
                 "column_name": "booking_class",
-                "column_description": ["The booking class associated with the fare basis"]
+                "column_description": "The booking class associated with the fare basis"
             },
             {
                 "data_type": "text",
                 "column_name": "class_type",
-                "column_description": ["The class type associated with the fare basis"]
+                "column_description": "The class type associated with the fare basis"
             },
             {
                 "data_type": "text",
                 "column_name": "premium",
-                "column_description": ["Indicates whether the fare basis is for a premium class"]
+                "column_description": "Indicates whether the fare basis is for a premium class"
             },
             {
                 "data_type": "text",
                 "column_name": "economy",
-                "column_description": ["Indicates whether the fare basis is for an economy class"]
+                "column_description": "Indicates whether the fare basis is for an economy class"
             },
             {
                 "data_type": "text",
                 "column_name": "discounted",
-                "column_description": ["Indicates whether the fare basis is for a discounted fare"]
+                "column_description": "Indicates whether the fare basis is for a discounted fare"
             },
             {
                 "data_type": "text",
                 "column_name": "night",
-                "column_description": ["Indicates whether the fare basis is for a night fare"]
+                "column_description": "Indicates whether the fare basis is for a night fare"
             },
             {
                 "data_type": "text",
                 "column_name": "season",
-                "column_description": ["The season associated with the fare basis"]
+                "column_description": "The season associated with the fare basis"
             },
             {
                 "data_type": "text",
                 "column_name": "basis_days",
-                "column_description": ["The number of days the fare basis is valid for"]
+                "column_description": "The number of days the fare basis is valid for"
             }
         ],
         "flight_leg": [
             {
                 "data_type": "bigint",
                 "column_name": "flight_id",
-                "column_description": ["Unique identifier for each flight"]
+                "column_description": "Unique identifier for each flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "leg_number",
-                "column_description": ["The sequence number of the leg within the flight"]
+                "column_description": "The sequence number of the leg within the flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "leg_flight",
-                "column_description": ["The flight ID of the leg's corresponding flight"]
+                "column_description": "The flight ID of the leg's corresponding flight"
             }
         ],
         "flight_fare": [
             {
                 "data_type": "bigint",
                 "column_name": "flight_id",
-                "column_description": ["Unique identifier for each flight"]
+                "column_description": "Unique identifier for each flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "fare_id",
-                "column_description": ["Unique identifier for each fare"]
+                "column_description": "Unique identifier for each fare"
             }
         ],
         "flight_stop": [
             {
                 "data_type": "bigint",
                 "column_name": "flight_id",
-                "column_description": ["Unique identifier for each flight"]
+                "column_description": "Unique identifier for each flight"
             },
             {
                 "data_type": "bigint",
                 "column_name": "stop_number",
-                "column_description": ["The order of the stop in the flight"]
+                "column_description": "The order of the stop in the flight"
             },
             {
                 "data_type": "text",
                 "column_name": "arrival_flight_number",
-                "column_description": ["Flight number of the arriving flight at this stop"]
+                "column_description": "Flight number of the arriving flight at this stop"
             },
             {
                 "data_type": "bigint",
                 "column_name": "departure_time",
-                "column_description": ["The time at which the flight departs from this stop. This is in Unix timestamp format. Always convert to regular date time format."]
+                "column_description": "The time at which the flight departs from this stop. This is in Unix timestamp format. Always convert to regular date time format."
             },
             {
                 "data_type": "text",
                 "column_name": "departure_flight_number",
-                "column_description": ["Flight number of the departing flight from this stop"]
+                "column_description": "Flight number of the departing flight from this stop"
             },
             {
                 "data_type": "bigint",
                 "column_name": "stop_time",
-                "column_description": ["The duration of the stop at this airport"]
+                "column_description": "The duration of the stop at this airport"
             },
             {
                 "data_type": "bigint",
                 "column_name": "arrival_time",
-                "column_description": ["The time at which the flight arrives at this stop. This is in Unix timestamp format. Always convert to regular date time format."]
+                "column_description": "The time at which the flight arrives at this stop. This is in Unix timestamp format. Always convert to regular date time format."
             },
             {
                 "data_type": "text",
                 "column_name": "stop_days",
-                "column_description": ["Days of the week on which the flight stops at this airport"]
+                "column_description": "Days of the week on which the flight stops at this airport"
             },
             {
                 "data_type": "text",
                 "column_name": "stop_airport",
-                "column_description": ["The 3-letter airport code of the stop"]
+                "column_description": "The 3-letter airport code of the stop"
             },
             {
                 "data_type": "text",
                 "column_name": "departure_airline",
-                "column_description": ["The airline code of the departing flight"]
+                "column_description": "The airline code of the departing flight"
             },
             {
                 "data_type": "text",
                 "column_name": "arrival_airline",
-                "column_description": ["The airline code of the arriving flight"]
+                "column_description": "The airline code of the arriving flight"
             }
         ],
         "restriction": [
             {
                 "data_type": "bigint",
                 "column_name": "maximum_stay",
-                "column_description": ["The maximum length of stay allowed for the fare."]
+                "column_description": "The maximum length of stay allowed for the fare."
             },
             {
                 "data_type": "bigint",
                 "column_name": "advance_purchase",
-                "column_description": ["The number of days in advance the fare must be purchased."]
+                "column_description": "The number of days in advance the fare must be purchased."
             },
             {
                 "data_type": "bigint",
                 "column_name": "minimum_stay",
-                "column_description": ["The minimum length of stay required for the fare."]
+                "column_description": "The minimum length of stay required for the fare."
             },
             {
                 "data_type": "text",
                 "column_name": "application",
-                "column_description": ["The type of fare application, such as one-way or round-trip."]
+                "column_description": "The type of fare application, such as one-way or round-trip."
             },
             {
                 "data_type": "text",
                 "column_name": "restriction_code",
-                "column_description": ["A code representing the type of restriction, such as blackout dates or minimum stay."]
+                "column_description": "A code representing the type of restriction, such as blackout dates or minimum stay."
             },
             {
                 "data_type": "text",
                 "column_name": "no_discounts",
-                "column_description": ["Indicates whether the fare is eligible for discounts or promotions."]
+                "column_description": "Indicates whether the fare is eligible for discounts or promotions."
             },
             {
                 "data_type": "text",
                 "column_name": "stopovers",
-                "column_description": ["The number of stopovers allowed for the fare."]
+                "column_description": "The number of stopovers allowed for the fare."
             },
             {
                 "data_type": "text",
                 "column_name": "saturday_stay_required",
-                "column_description": ["Indicates whether a Saturday night stay is required for the fare."]
+                "column_description": "Indicates whether a Saturday night stay is required for the fare."
             }
         ],
         "dual_carrier": [
             {
                 "data_type": "bigint",
                 "column_name": "low_flight_number",
-                "column_description": ["The lowest flight number in the range of flights operated by the dual carrier"]
+                "column_description": "The lowest flight number in the range of flights operated by the dual carrier"
             },
             {
                 "data_type": "bigint",
                 "column_name": "high_flight_number",
-                "column_description": ["The highest flight number in the range of flights operated by the dual carrier"]
+                "column_description": "The highest flight number in the range of flights operated by the dual carrier"
             },
             {
                 "data_type": "text",
                 "column_name": "main_airline",
-                "column_description": ["The name of the main airline operating the flight"]
+                "column_description": "The name of the main airline operating the flight"
             },
             {
                 "data_type": "text",
                 "column_name": "dual_airline",
-                "column_description": ["The name of the dual airline operating the flight"]
+                "column_description": "The name of the dual airline operating the flight"
             },
             {
                 "data_type": "text",
                 "column_name": "service_name",
-                "column_description": ["The name of the service provided by the dual carrier on the flight"]
+                "column_description": "The name of the service provided by the dual carrier on the flight"
             }
         ],
         "food_service": [
             {
                 "data_type": "bigint",
                 "column_name": "meal_number",
-                "column_description": ["Unique identifier for each meal served"]
+                "column_description": "Unique identifier for each meal served"
             },
             {
                 "data_type": "text",
                 "column_name": "meal_code",
-                "column_description": ["Code assigned to each meal type"]
+                "column_description": "Code assigned to each meal type"
             },
             {
                 "data_type": "text",
                 "column_name": "compartment",
-                "column_description": ["The compartment in which the meal is served (e.g. first class, economy)"]
+                "column_description": "The compartment in which the meal is served (e.g. first class, economy)"
             },
             {
                 "data_type": "text",
                 "column_name": "meal_description",
-                "column_description": ["Detailed description of the meal served"]
+                "column_description": "Detailed description of the meal served"
             }
         ],
         "time_interval": [
             {
                 "data_type": "bigint",
                 "column_name": "begin_time",
-                "column_description": ["The beginning time of the time interval in Unix timestamp format. Always convert to regular date time format."]
+                "column_description": "The beginning time of the time interval in Unix timestamp format. Always convert to regular date time format."
             },
             {
                 "data_type": "bigint",
                 "column_name": "end_time",
-                "column_description": ["The end time of the time interval in Unix timestamp format. Always convert to regular date time format."]
+                "column_description": "The end time of the time interval in Unix timestamp format. Always convert to regular date time format."
             },
             {
                 "data_type": "text",
                 "column_name": "period",
-                "column_description": ["The period of the time interval, represented as a string. For example, 'daily', 'weekly', 'monthly', etc."]
+                "column_description": "The period of the time interval, represented as a string. For example, 'daily', 'weekly', 'monthly', etc."
             }
         ],
         "ground_service": [
             {
                 "data_type": "bigint",
                 "column_name": "ground_fare",
-                "column_description": ["The fare charged for ground transportation"]
+                "column_description": "The fare charged for ground transportation"
             },
             {
                 "data_type": "text",
                 "column_name": "city_code",
-                "column_description": ["The code for the city where the ground service is provided"]
+                "column_description": "The code for the city where the ground service is provided"
             },
             {
                 "data_type": "text",
                 "column_name": "airport_code",
-                "column_description": ["The 3-letter code for the airport where the ground service is provided"]
+                "column_description": "The 3-letter code for the airport where the ground service is provided"
             },
             {
                 "data_type": "text",
                 "column_name": "transport_type",
-                "column_description": ["The type of ground transportation provided"]
+                "column_description": "The type of ground transportation provided"
             }
         ],
         "airport_service": [
             {
                 "data_type": "bigint",
                 "column_name": "miles_distant",
-                "column_description": ["The distance of the airport from the city in miles"]
+                "column_description": "The distance of the airport from the city in miles"
             },
             {
                 "data_type": "bigint",
                 "column_name": "minutes_distant",
-                "column_description": ["The distance of the airport from the city in minutes"]
+                "column_description": "The distance of the airport from the city in minutes"
             },
             {
                 "data_type": "text",
                 "column_name": "city_code",
-                "column_description": ["The code of the city where the airport is located"]
+                "column_description": "The code of the city where the airport is located"
             },
             {
                 "data_type": "text",
                 "column_name": "airport_code",
-                "column_description": ["The code of the airport"]
+                "column_description": "The code of the airport"
             },
             {
                 "data_type": "text",
                 "column_name": "direction",
-                "column_description": ["The direction of the airport from the city"]
+                "column_description": "The direction of the airport from the city"
             }
         ],
         "class_of_service": [
             {
                 "data_type": "bigint",
                 "column_name": "rank",
-                "column_description": ["The rank of the class of service"]
+                "column_description": "The rank of the class of service"
             },
             {
                 "data_type": "text",
                 "column_name": "booking_class",
-                "column_description": ["The booking class code for the class of service"]
+                "column_description": "The booking class code for the class of service"
             },
             {
                 "data_type": "text",
                 "column_name": "class_description",
-                "column_description": ["A brief description of the class of service"]
+                "column_description": "A brief description of the class of service"
             }
         ],
         "code_description": [
             {
                 "data_type": "text",
                 "column_name": "code",
-                "column_description": ["The code column contains a unique identifier for each record in the table."]
+                "column_description": "The code column contains a unique identifier for each record in the table."
             },
             {
                 "data_type": "text",
                 "column_name": "description",
-                "column_description": ["The description column contains a textual description of the code."]
+                "column_description": "The description column contains a textual description of the code."
             }
         ],
         "compartment_class": [
             {
                 "data_type": "text",
                 "column_name": "compartment",
-                "column_description": ["The compartment column contains the name of a compartment."]
+                "column_description": "The compartment column contains the name of a compartment."
             },
             {
                 "data_type": "text",
                 "column_name": "class_type",
-                "column_description": ["The class_type column contains the type of a class."]
+                "column_description": "The class_type column contains the type of a class."
             }
         ],
         "equipment_sequence": [
             {
                 "data_type": "text",
                 "column_name": "aircraft_code_sequence",
-                "column_description": ["Sequence number for each aircraft code"]
+                "column_description": "Sequence number for each aircraft code"
             },
             {
                 "data_type": "text",
                 "column_name": "aircraft_code",
-                "column_description": ["Code for each aircraft"]
+                "column_description": "Code for each aircraft"
             }
         ]
-    },
-    "glossary": "",
-    "table_descriptions": {
-        "city": "The \"city\" table contains information about various cities, including their codes, names, the codes of the states they belong to, the names of the countries they are located in, and the codes of the time zones they are in. This table can be joined with the \"state\" table using the \"state_code\" column to get additional information about the states where the cities are located.",
-        "days": "The \"days\" table is used to store information about the days of the week. It contains two columns: \"days_code\" which represents a code for each day of the week, and \"day_name\" which stores the name of each day. This table can be joined with other tables in the database to provide additional context or information about specific days.",
-        "fare": "The \"fare\" table contains information about fares for flights. It includes columns such as \"one_direction_cost\" (the cost of a one-way trip for this fare), \"round_trip_cost\" (the cost of a round-trip for this fare), \"fare_id\" (the unique identifier for this fare), \"fare_basis_code\" (the code used to determine the fare's pricing rules), \"fare_airline\" (the airline associated with this fare), \"restriction_code\" (any restrictions or limitations associated with this fare), \"round_trip_required\" (indicates whether a round-trip is required to purchase this fare), \"from_airport\" (the 3-letter airport code for the departure location), and \"to_airport\" (the 3-letter airport code for the arrival location).\n\nThis table can be joined with the \"flight\" table using the \"fare_id\" column to get information about the flights associated with each fare.",
-        "month": "The \"month\" table is used to store information about each month of the year. It has two columns: \"month_number\" which is a unique number assigned to each month, and \"month_name\" which stores the name of the month. This table can be joined with other tables in the database to analyze data based on specific months.",
-        "state": "The \"state\" table contains information about different states. It can be joined with the \"city\" table to get the cities within each state.",
-        "flight": "The \"flight\" table contains information about flights, including their unique identifier, departure and arrival times, flight number, number of stops and connections, total time elapsed, airline code, dual carrier code, flight days, departure and arrival airports, aircraft code sequence, and meal code. This table can be joined with the \"airline\" table.",
-        "airline": "The \"airline\" table contains information about different airlines. It can be joined with the \"flight\" table to retrieve flights operated by each airline.",
-        "airport": "The \"airport\" table contains information about airports, including their names, locations, codes, and minimum connect times for connecting flights. It also includes the country and state codes where the airport is located, as well as the code for the time zone. This table can be joined with other tables such as \"city\", \"state\", and \"time_zone\" to gather additional information about the airports.",
-        "aircraft": "The \"aircraft\" table contains information about various aircraft. It includes details such as the length, weight, capacity, payload, cruising speed, range, number of engines, wing span, pressurization status, aircraft description, manufacturer, basic type, propulsion type, wide body status, and the IATA code assigned to the aircraft. This table can be joined with other tables such as \"flight\" or \"airline\" to analyze flight data or with \"airport\" to associate aircraft with specific airports.",
-        "time_zone": "The \"time_zone\" table contains information about different time zones. It can be joined with other tables such as \"city\", \"days\", \"fare\", \"month\", \"state\", \"flight\", \"airline\", \"airport\", \"aircraft\", \"fare_basis\", \"flight_leg\", \"flight_fare\", \"flight_stop\", \"restriction\", \"dual_carrier\", \"food_service\", \"time_interval\", \"ground_service\", \"airport_service\", \"class_of_service\", \"code_description\", and \"compartment_class\". The table includes columns for the number of hours that the time zone is ahead or behind Greenwich Mean Time (GMT), a short code representing the time zone, and the name of the time zone.",
-        "fare_basis": "The \"fare_basis\" table contains information about fare basis codes and their associated booking classes, class types, and other attributes. It can be joined with other tables such as \"flight\", \"airline\", \"airport\", and \"class_of_service\" to analyze and understand the fare basis codes used in different flights, airlines, and airports.",
-        "flight_leg": "The \"flight_leg\" table is used to store information about the legs of a flight. Each leg is identified by a unique \"flight_id\" and \"leg_number\" within the flight. The \"leg_flight\" column represents the flight ID of the leg's corresponding flight. This table can be joined with the \"flight\" table using the \"flight_id\" column to retrieve additional details about the flight.",
-        "flight_fare": "The \"flight_fare\" table is used to store information about the fares associated with each flight. It contains two columns: \"flight_id\" and \"fare_id\", which are unique identifiers for each flight and fare respectively. This table can be joined with the \"flight\" table using the \"flight_id\" column to retrieve additional details about the flight.",
-        "flight_stop": "The \"flight_stop\" table contains information about the stops made by flights. It includes details such as the flight ID, the order of the stop in the flight, the flight number of the arriving and departing flights at this stop, the departure and arrival times, the duration of the stop, the days of the week on which the flight stops at this airport, the 3-letter airport code of the stop, and the airline codes of the departing and arriving flights. This table can be joined with the \"flight\" table to get additional information about the flights.",
-        "restriction": "The \"restriction\" table contains information about the restrictions associated with fares. It can be joined with tables such as \"fare\", \"flight\", \"flight_fare\", and \"flight_stop\" to retrieve additional details about the fares and flights. The table includes columns such as \"maximum_stay\", \"advance_purchase\", \"minimum_stay\", \"application\", \"restriction_code\", \"no_discounts\", \"stopovers\", and \"saturday_stay_required\" which provide information about the length of stay, purchase requirements, fare application type, restriction codes, eligibility for discounts, number of stopovers, and whether a Saturday night stay is required for the fare.",
-        "dual_carrier": "The \"dual_carrier\" table contains information about flights operated by a dual carrier. It includes the lowest and highest flight numbers in the range of flights operated by the dual carrier, as well as the names of the main and dual airlines operating the flight. Additionally, it provides the name of the service provided by the dual carrier on the flight. This table can be joined with other tables such as \"flight\" or \"airline\" to gather more information about the flights and airlines involved.",
-        "food_service": "The \"food_service\" table is used to store information about meals served in a food service. It contains a unique identifier for each meal served, a code assigned to each meal type, the compartment in which the meal is served (e.g. first class, economy), and a detailed description of the meal served. This table can be joined with other tables such as \"flight\", \"airline\", \"airport\", and \"compartment_class\" to gather additional information about the flights, airlines, airports, and compartment classes associated with each meal.",
-        "time_interval": "The \"time_interval\" table represents different time intervals and their corresponding periods. It contains the columns \"begin_time\" and \"end_time\" which store the start and end times of each interval in Unix timestamp format. Additionally, the \"period\" column stores the period of the time interval as a string, such as 'daily', 'weekly', 'monthly', etc. This table can be joined with other tables in the database, such as \"city\", \"days\", \"fare\", \"month\", \"state\", \"flight\", \"airline\", \"airport\", \"aircraft\", \"time_zone\", \"fare_basis\", \"flight_leg\", \"flight_fare\", \"flight_stop\", \"restriction\", \"dual_carrier\", \"food_service\", \"time_interval\", \"ground_service\", \"airport_service\", \"class_of_service\", \"code_description\", \"compartment_class\", and \"equipment_sequence\".",
-        "ground_service": "The \"ground_service\" table contains information about the fare charged for ground transportation services provided in different cities and airports. It includes columns such as \"ground_fare\" (representing the fare charged for the service), \"city_code\" (representing the code for the city where the ground service is provided), \"airport_code\" (representing the 3-letter code for the airport where the ground service is provided), and \"transport_type\" (representing the type of ground transportation provided). This table can be joined with other tables such as \"city\", \"airport\", and \"transport_type\" to gather additional information about the cities, airports, and types of ground transportation associated with the ground services.",
-        "airport_service": "The \"airport_service\" table contains information about the distance and direction of airports from their respective cities. It can be joined with the \"city\" table to get additional details about the city where the airport is located.",
-        "class_of_service": "The \"class_of_service\" table contains information about different classes of service offered by an airline. It includes the rank of each class, the booking class code, and a brief description of the class. This table can be joined with other tables such as \"flight_fare\" or \"flight_leg\" to associate specific fares or flight legs with each class of service.",
-        "code_description": "The table \"]code_description\" contains a unique identifier code and a corresponding textual description for each record. It can be joined with other tables in the database to provide additional information or context based on the code values.",
-        "compartment_class": "The \"compartment_class\" table contains information about different compartments and their corresponding class types. It can be joined with other tables such as \"flight\", \"airline\", \"airport\", and \"class_of_service\" to provide additional details about the compartments and their associated flights, airlines, and airports.",
-        "equipment_sequence": "The table \"equipment_sequence\" is used to store the sequence number for each aircraft code. It has two columns: \"aircraft_code_sequence\" which represents the sequence number, and \"aircraft_code\" which represents the code for each aircraft. This table can be joined with the \"aircraft\" table."
     }
 }

--- a/geography/geography.json
+++ b/geography/geography.json
@@ -1,174 +1,163 @@
 {
-    "status": "success",
     "table_metadata": {
         "city": [
             {
                 "data_type": "bigint",
                 "column_name": "population",
-                "column_description": ["The population of the city"]
+                "column_description": "The population of the city"
             },
             {
                 "data_type": "text",
                 "column_name": "city_name",
-                "column_description": ["The name of the city"]
+                "column_description": "The name of the city"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country where the city is located"]
+                "column_description": "The name of the country where the city is located"
             },
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state where the city is located"]
+                "column_description": "The name of the state where the city is located"
             }
         ],
         "lake": [
             {
                 "data_type": "double precision",
                 "column_name": "area",
-                "column_description": ["The area of the lake in square kilometers"]
+                "column_description": "The area of the lake in square kilometers"
             },
             {
                 "data_type": "text",
                 "column_name": "lake_name",
-                "column_description": ["The name of the lake"]
+                "column_description": "The name of the lake"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country where the lake is located"]
+                "column_description": "The name of the country where the lake is located"
             },
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state where the lake is located (if applicable)"]
+                "column_description": "The name of the state where the lake is located (if applicable)"
             }
         ],
         "river": [
             {
                 "data_type": "bigint",
                 "column_name": "length",
-                "column_description": ["The length of the river in meters"]
+                "column_description": "The length of the river in meters"
             },
             {
                 "data_type": "text",
                 "column_name": "river_name",
-                "column_description": ["The name of the river. Names exclude the word 'river' e.g. 'Mississippi' instead of 'Mississippi River'"]
+                "column_description": "The name of the river. Names exclude the word 'river' e.g. 'Mississippi' instead of 'Mississippi River'"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country the river flows through"]
+                "column_description": "The name of the country the river flows through"
             },
             {
                 "data_type": "text",
                 "column_name": "traverse",
-                "column_description": ["The cities or landmarks the river passes through. Comma delimited, eg `new york,albany,boston`"]
+                "column_description": "The cities or landmarks the river passes through. Comma delimited, eg `new york,albany,boston`"
             }
         ],
         "state": [
             {
                 "data_type": "bigint",
                 "column_name": "population",
-                "column_description": ["The population of the state"]
+                "column_description": "The population of the state"
             },
             {
                 "data_type": "double precision",
                 "column_name": "area",
-                "column_description": ["The area of the state in square kilometers"]
+                "column_description": "The area of the state in square kilometers"
             },
             {
                 "data_type": "double precision",
                 "column_name": "density",
-                "column_description": ["The population density of the state in people per square kilometer"]
+                "column_description": "The population density of the state in people per square kilometer"
             },
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state"]
+                "column_description": "The name of the state"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country the state belongs to"]
+                "column_description": "The name of the country the state belongs to"
             },
             {
                 "data_type": "text",
                 "column_name": "capital",
-                "column_description": ["The name of the capital city of the state"]
+                "column_description": "The name of the capital city of the state"
             }
         ],
         "highlow": [
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state"]
+                "column_description": "The name of the state"
             },
             {
                 "data_type": "text",
                 "column_name": "highest_elevation",
-                "column_description": ["The highest elevation point in the state in meters above sea level"]
+                "column_description": "The highest elevation point in the state in meters above sea level"
             },
             {
                 "data_type": "text",
                 "column_name": "lowest_point",
-                "column_description": ["The lowest elevation point in the state"]
+                "column_description": "The lowest elevation point in the state"
             },
             {
                 "data_type": "text",
                 "column_name": "highest_point",
-                "column_description": ["The highest point in the state"]
+                "column_description": "The highest point in the state"
             },
             {
                 "data_type": "text",
                 "column_name": "lowest_elevation",
-                "column_description": ["The lowest point in the state in meters above sea level"]
+                "column_description": "The lowest point in the state in meters above sea level"
             }
         ],
         "mountain": [
             {
                 "data_type": "bigint",
                 "column_name": "mountain_altitude",
-                "column_description": ["The altitude of the mountain in meters"]
+                "column_description": "The altitude of the mountain in meters"
             },
             {
                 "data_type": "text",
                 "column_name": "mountain_name",
-                "column_description": ["The name of the mountain"]
+                "column_description": "The name of the mountain"
             },
             {
                 "data_type": "text",
                 "column_name": "country_name",
-                "column_description": ["The name of the country where the mountain is located"]
+                "column_description": "The name of the country where the mountain is located"
             },
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state or province where the mountain is located (if applicable)"]
+                "column_description": "The name of the state or province where the mountain is located (if applicable)"
             }
         ],
         "border_info": [
             {
                 "data_type": "text",
                 "column_name": "state_name",
-                "column_description": ["The name of the state that shares a border with another state or country."]
+                "column_description": "The name of the state that shares a border with another state or country."
             },
             {
                 "data_type": "text",
                 "column_name": "border",
-                "column_description": ["The name of the state that shares a border with the state specified in the state_name column."]
+                "column_description": "The name of the state that shares a border with the state specified in the state_name column."
             }
         ]
-    },
-    "glossary": "",
-    "table_descriptions": {
-        "city": "The \"city\" table contains information about cities, including their population, name, country, and state. This table can be joined with other tables such as \"lake\", \"river\", \"state\", \"highlow\", \"mountain\", and \"border_info\" to gather additional information about the cities, such as their proximity to lakes, rivers, mountains, or borders.",
-        "lake": "The \"lake\" table contains information about lakes, including their area, name, country, and state (if applicable). This table can be joined with other tables such as \"city\", \"river\", \"state\", \"highlow\", \"mountain\", and \"border_info\" to gather additional information about the lakes.",
-        "river": "The \"river\" table contains information about rivers, including their length, name, the country they flow through, and the cities or landmarks they pass through. This table can be joined with other tables such as \"city\", \"lake\", \"state\", and \"mountain\" to gather additional information about the rivers.",
-        "state": "The \"state\" table contains information about different states, including their population, area, population density, state name, country name, and capital city. This table can be joined with other tables such as \"city\", \"lake\", \"river\", \"highlow\", \"mountain\", and \"border_info\" to gather additional information about the states.",
-        "highlow": "The \"highlow\" table contains information about the highest and lowest elevations and points in each state. It can be joined with the  \"city\", \"lake\", \"state\", \"mountain\", and \"border_info\" tables to retrieve additional information about each state.",
-        "mountain": "The \"mountain\" table contains information about mountains, including their altitude, name, country, and state (if applicable). This table can be joined with other tables such as \"city\", \"lake\", \"river\", \"state\", \"highlow\", and \"border_info\" to gather additional information about the mountains.",
-        "border_info": "The \"border_info\" table contains information about the borders of states. It includes the name of a state and the name of the state that shares a border with it. This table can be joined with other tables such as \"city\", \"lake\", \"state\", \"highlow\", or \"mountain\" to gather additional information about the borders."
     }
 }

--- a/restaurants/restaurants.json
+++ b/restaurants/restaurants.json
@@ -1,77 +1,70 @@
 {
-    "status": "success",
     "table_metadata": {
         "location": [
             {
                 "data_type": "bigint",
                 "column_name": "restaurant_id",
-                "column_description": ["Unique identifier for each restaurant"]
+                "column_description": "Unique identifier for each restaurant"
             },
             {
                 "data_type": "bigint",
                 "column_name": "house_number",
-                "column_description": ["The number assigned to the building where the restaurant is located"]
+                "column_description": "The number assigned to the building where the restaurant is located"
             },
             {
                 "data_type": "text",
                 "column_name": "street_name",
-                "column_description": ["The name of the street where the restaurant is located"]
+                "column_description": "The name of the street where the restaurant is located"
             },
             {
                 "data_type": "text",
                 "column_name": "city_name",
-                "column_description": ["The name of the city where the restaurant is located"]
+                "column_description": "The name of the city where the restaurant is located"
             }
         ],
         "geographic": [
             {
                 "data_type": "text",
                 "column_name": "city_name",
-                "column_description": ["The name of the city"]
+                "column_description": "The name of the city"
             },
             {
                 "data_type": "text",
                 "column_name": "county",
-                "column_description": ["The name of the county"]
+                "column_description": "The name of the county"
             },
             {
                 "data_type": "text",
                 "column_name": "region",
-                "column_description": ["The name of the region"]
+                "column_description": "The name of the region"
             }
         ],
         "restaurant": [
             {
                 "data_type": "bigint",
                 "column_name": "id",
-                "column_description": ["Unique identifier for each restaurant"]
+                "column_description": "Unique identifier for each restaurant"
             },
             {
                 "data_type": "real",
                 "column_name": "rating",
-                "column_description": ["The rating of the restaurant on a scale of 0 to 5"]
+                "column_description": "The rating of the restaurant on a scale of 0 to 5"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["The name of the restaurant"]
+                "column_description": "The name of the restaurant"
             },
             {
                 "data_type": "text",
                 "column_name": "food_type",
-                "column_description": ["The type of food served at the restaurant"]
+                "column_description": "The type of food served at the restaurant"
             },
             {
                 "data_type": "text",
                 "column_name": "city_name",
-                "column_description": ["The city where the restaurant is located"]
+                "column_description": "The city where the restaurant is located"
             }
         ]
-    },
-    "glossary": "",
-    "table_descriptions": {
-        "location": "The \"location\" table is used to store information about the location of restaurants. It contains columns such as \"restaurant_id\" to uniquely identify each restaurant, \"house_number\" to represent the number assigned to the building where the restaurant is located, \"street_name\" to store the name of the street, and \"city_name\" to store the name of the city. This table can be joined with the \"geographic\" and \"restaurant\" tables to retrieve additional information about the restaurants or to perform location-based queries.",
-        "geographic": "The \"geographic\" table is used to store information about cities, counties, and regions. It can be joined with the \"location\" table, the \"geographic\" table itself, or the \"restaurant\" table.",
-        "restaurant": "The \"restaurant\" table is used to store information about different restaurants. It contains columns for the unique identifier of each restaurant, the rating of the restaurant, the name of the restaurant, the type of food served at the restaurant, and the city where the restaurant is located. This table can be joined with the \"location\", \"geographic\", or \"restaurant\" tables."
     }
 }

--- a/scholar/scholar.json
+++ b/scholar/scholar.json
@@ -1,184 +1,168 @@
 {
-    "status": "success",
     "table_metadata": {
         "cite": [
             {
                 "data_type": "bigint",
                 "column_name": "citingpaperid",
-                "column_description": ["The ID of the paper that is doing the citing."]
+                "column_description": "The ID of the paper that is doing the citing."
             },
             {
                 "data_type": "bigint",
                 "column_name": "citedpaperid",
-                "column_description": ["The ID of the paper that is being cited."]
+                "column_description": "The ID of the paper that is being cited."
             }
         ],
         "field": [
             {
                 "data_type": "bigint",
                 "column_name": "fieldid",
-                "column_description": ["Unique identifier for each field in the table"]
+                "column_description": "Unique identifier for each field in the table"
             }
         ],
         "paper": [
             {
                 "data_type": "bigint",
                 "column_name": "year",
-                "column_description": ["The year the paper was published."]
+                "column_description": "The year the paper was published."
             },
             {
                 "data_type": "bigint",
                 "column_name": "journalid",
-                "column_description": ["The ID of the journal where the paper was published."]
+                "column_description": "The ID of the journal where the paper was published."
             },
             {
                 "data_type": "bigint",
                 "column_name": "venueid",
-                "column_description": ["The ID of the venue where the paper was published."]
+                "column_description": "The ID of the venue where the paper was published."
             },
             {
                 "data_type": "bigint",
                 "column_name": "paperid",
-                "column_description": ["The unique ID of the paper."]
+                "column_description": "The unique ID of the paper."
             },
             {
                 "data_type": "bigint",
                 "column_name": "numciting",
-                "column_description": ["The number of papers that this paper cites."]
+                "column_description": "The number of papers that this paper cites."
             },
             {
                 "data_type": "bigint",
                 "column_name": "numcitedby",
-                "column_description": ["The number of papers that cite this paper."]
+                "column_description": "The number of papers that cite this paper."
             },
             {
                 "data_type": "text",
                 "column_name": "title",
-                "column_description": ["The title of the paper, enclosed in double quotes if it contains commas."]
+                "column_description": "The title of the paper, enclosed in double quotes if it contains commas."
             }
         ],
         "venue": [
             {
                 "data_type": "bigint",
                 "column_name": "venueid",
-                "column_description": ["Unique identifier for each venue"]
+                "column_description": "Unique identifier for each venue"
             },
             {
                 "data_type": "text",
                 "column_name": "venuename",
-                "column_description": ["Name of the venue"]
+                "column_description": "Name of the venue"
             }
         ],
         "author": [
             {
                 "data_type": "bigint",
                 "column_name": "authorid",
-                "column_description": ["Unique identifier for each author"]
+                "column_description": "Unique identifier for each author"
             },
             {
                 "data_type": "text",
                 "column_name": "authorname",
-                "column_description": ["Name of the author"]
+                "column_description": "Name of the author"
             }
         ],
         "writes": [
             {
                 "data_type": "bigint",
                 "column_name": "paperid",
-                "column_description": ["The unique identifier for a paper in the writes table."]
+                "column_description": "The unique identifier for a paper in the writes table."
             },
             {
                 "data_type": "bigint",
                 "column_name": "authorid",
-                "column_description": ["The unique identifier for an author in the writes table."]
+                "column_description": "The unique identifier for an author in the writes table."
             }
         ],
         "dataset": [
             {
                 "data_type": "bigint",
                 "column_name": "datasetid",
-                "column_description": ["Unique identifier for each dataset in the table"]
+                "column_description": "Unique identifier for each dataset in the table"
             },
             {
                 "data_type": "text",
                 "column_name": "datasetname",
-                "column_description": ["Name of the dataset"]
+                "column_description": "Name of the dataset"
             }
         ],
         "journal": [
             {
                 "data_type": "bigint",
                 "column_name": "journalid",
-                "column_description": ["Unique identifier for each journal entry"]
+                "column_description": "Unique identifier for each journal entry"
             },
             {
                 "data_type": "text",
                 "column_name": "journalname",
-                "column_description": ["Name or title of the journal"]
+                "column_description": "Name or title of the journal"
             }
         ],
         "keyphrase": [
             {
                 "data_type": "bigint",
                 "column_name": "keyphraseid",
-                "column_description": ["Unique identifier for each keyphrase"]
+                "column_description": "Unique identifier for each keyphrase"
             },
             {
                 "data_type": "text",
                 "column_name": "keyphrasename",
-                "column_description": ["The actual keyphrase text"]
+                "column_description": "The actual keyphrase text"
             }
         ],
         "paperfield": [
             {
                 "data_type": "bigint",
                 "column_name": "fieldid",
-                "column_description": ["Unique identifier for each field in the table"]
+                "column_description": "Unique identifier for each field in the table"
             },
             {
                 "data_type": "bigint",
                 "column_name": "paperid",
-                "column_description": ["Unique identifier for each paper in the table"]
+                "column_description": "Unique identifier for each paper in the table"
             }
         ],
         "paperdataset": [
             {
                 "data_type": "bigint",
                 "column_name": "paperid",
-                "column_description": ["Unique identifier for each paper in the dataset"]
+                "column_description": "Unique identifier for each paper in the dataset"
             },
             {
                 "data_type": "bigint",
                 "column_name": "datasetid",
-                "column_description": ["Unique identifier for each dataset that the paper belongs to"]
+                "column_description": "Unique identifier for each dataset that the paper belongs to"
             }
         ],
         "paperkeyphrase": [
             {
                 "data_type": "bigint",
                 "column_name": "paperid",
-                "column_description": ["The ID of the paper associated with the keyphrase."]
+                "column_description": "The ID of the paper associated with the keyphrase."
             },
             {
                 "data_type": "bigint",
                 "column_name": "keyphraseid",
-                "column_description": ["The ID of the keyphrase associated with the paper."]
+                "column_description": "The ID of the keyphrase associated with the paper."
             }
         ]
-    },
-    "glossary": "This database contains information about different academic papers, the citing relationships between them, and other properties about the paper (author, journal, field, venue, key phrases, datasets).",
-    "table_descriptions": {
-        "cite": "The \"cite\" table is used to store information about citations between papers. It contains two columns: \"citingpaperid\" and \"citedpaperid\", which represent the IDs of the papers involved in the citation. This table can be joined with other tables such as \"paper\", \"paperdataset\", \"paperfield\", \"paperkeyphrase\", or \"writes\" to retrieve additional information about the papers involved in the citation.",
-        "field": "The \"field\" table is used to store unique identifiers for each field. It can be joined with the \"paperfield\" table to retrieve additional information related to these fields.",
-        "paper": "The \"paper\" table contains information about academic papers, including the year of publication, the journal and venue where the paper was published, and various identifiers for the paper. It also includes the number of papers that this paper cites and the number of papers that cite this paper. The table also includes the title of the paper. This table can be joined with other tables such as \"cite\", \"venue\", \"writes\", \"journal\", \"paperfield\", \"paperdataset\", and \"paperkeyphrase\" to gather additional information about the paper.",
-        "venue": "The \"venue\" table is used to store information about different venues. It has a unique identifier for each venue called \"venueid\" and the name of the venue is stored in the \"venuename\" column. This table can be joined with the table \"paper\".",
-        "author": "The \"author\" table is used to store information about authors. It contains a unique identifier for each author (authorid) and the name of the author (authorname). This table can be joined with the table \"writes\".",
-        "writes": "The \"writes\" table is used to store the relationship between papers and authors. It contains the unique identifiers for both the paper and the author. This table can be joined with the \"paper\", \"cite\", \"paperdataset\", \"paperfield\", \"paperkeyphrase\", and \"author\" tables to retrieve additional information about the papers and authors involved in the writing process.",
-        "dataset": "The \"dataset\" table is used to store information about different datasets. It has a unique identifier for each dataset called \"datasetid\" and the name of the dataset stored as text in the column \"datasetname\". This table can be joined with the table \"paperdataset\".",
-        "journal": "The \"journal\" table is used to store information about journal entries. It has two columns: \"journalid\" which is a unique identifier for each journal entry, and \"journalname\" which represents the name or title of the academic journal. This table can be joined with the table \"paper\".",
-        "keyphrase": "The \"keyphrase\" table is used to store unique keyphrases along with their corresponding identifiers. It can be joined with the table \"paperkeyphrase\" to establish relationships and retrieve additional information related to these keyphrases.",
-        "paperfield": "The \"paperfield\" table is used to store the relationship between papers and fields. It contains two columns: \"fieldid\" and \"paperid\", which are unique identifiers for each field and paper, respectively. This table can be joined with the \"field\" table to retrieve additional information about the fields associated with each paper.",
-        "paperdataset": "The \"paperdataset\" table is used to store the relationship between papers and datasets. It contains two columns: \"paperid\" which is a unique identifier for each paper in the dataset, and \"datasetid\" which is a unique identifier for each dataset that the paper belongs to. This table can be joined with the \"paper\", \"dataset\", \"cite\", \"paperfield\", \"paperkeyphrase\", and \"writes\" tables to retrieve additional information about the papers and datasets.",
-        "paperkeyphrase": "The \"paperkeyphrase\" table is used to store the association between papers and keyphrases. It contains the paper ID and the keyphrase ID as columns. This table can be joined with the \"cite\", \"keyphrase\", \"paper\", \"paperdataset\", \"paperfield\", and \"writes\" tables to retrieve additional information about the paper, or with the \"keyphrase\" table to get details about the keyphrase."
     }
 }

--- a/yelp/yelp.json
+++ b/yelp/yelp.json
@@ -1,214 +1,203 @@
 {
-    "status": "success",
     "table_metadata": {
         "tip": [
             {
                 "column_name": "year",
                 "data_type": "bigint",
-                "column_description": ["Year when the tip was created"]
+                "column_description": "Year when the tip was created"
             },
             {
                 "column_name": "tip_id",
                 "data_type": "bigint",
-                "column_description": ["Unique identifier for the tip"]
+                "column_description": "Unique identifier for the tip"
             },
             {
                 "column_name": "month",
                 "data_type": "text",
-                "column_description": ["Month when the tip was created"]
+                "column_description": "Month when the tip was created"
             },
             {
                 "column_name": "user_id",
                 "data_type": "text",
-                "column_description": ["Unique identifier for the user who created the tip"]
+                "column_description": "Unique identifier for the user who created the tip"
             },
             {
                 "column_name": "business_id",
                 "data_type": "text",
-                "column_description": ["Unique identifier for the business where the tip was created"]
+                "column_description": "Unique identifier for the business where the tip was created"
             },
             {
                 "column_name": "text",
                 "data_type": "text",
-                "column_description": ["Text content of the tip"]
+                "column_description": "Text content of the tip"
             }
         ],
         "users": [
             {
                 "data_type": "bigint",
                 "column_name": "uid",
-                "column_description": ["Unique identifier for each user"]
+                "column_description": "Unique identifier for each user"
             },
             {
                 "data_type": "text",
                 "column_name": "user_id",
-                "column_description": ["Unique user ID assigned by the system"]
+                "column_description": "Unique user ID assigned by the system"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["Name of the user"]
+                "column_description": "Name of the user"
             }
         ],
         "review": [
             {
                 "data_type": "real",
                 "column_name": "rating",
-                "column_description": ["The rating given by the user for the business, on a scale of 1 to 5."]
+                "column_description": "The rating given by the user for the business, on a scale of 1 to 5."
             },
             {
                 "data_type": "bigint",
                 "column_name": "rid",
-                "column_description": ["The unique identifier for each review."]
+                "column_description": "The unique identifier for each review."
             },
             {
                 "data_type": "bigint",
                 "column_name": "year",
-                "column_description": ["The year in which the review was posted."]
+                "column_description": "The year in which the review was posted."
             },
             {
                 "data_type": "text",
                 "column_name": "month",
-                "column_description": ["The month in which the review was posted."]
+                "column_description": "The month in which the review was posted."
             },
             {
                 "data_type": "text",
                 "column_name": "text",
-                "column_description": ["The text of the review."]
+                "column_description": "The text of the review."
             },
             {
                 "data_type": "text",
                 "column_name": "business_id",
-                "column_description": ["The unique identifier for the business being reviewed."]
+                "column_description": "The unique identifier for the business being reviewed."
             },
             {
                 "data_type": "text",
                 "column_name": "user_id",
-                "column_description": ["The unique identifier for the user who posted the review."]
+                "column_description": "The unique identifier for the user who posted the review."
             }
         ],
         "checkin": [
             {
                 "data_type": "bigint",
                 "column_name": "cid",
-                "column_description": ["Unique identifier for the daily check-in count"]
+                "column_description": "Unique identifier for the daily check-in count"
             },
             {
                 "data_type": "bigint",
                 "column_name": "count",
-                "column_description": ["Number of check-ins on the given day"]
+                "column_description": "Number of check-ins on the given day"
             },
             {
                 "data_type": "text",
                 "column_name": "business_id",
-                "column_description": ["Unique identifier for the business where the check-in occurred"]
+                "column_description": "Unique identifier for the business where the check-in occurred"
             },
             {
                 "data_type": "text",
                 "column_name": "day",
-                "column_description": ["Day of the week when the check-ins occurred"]
+                "column_description": "Day of the week when the check-ins occurred"
             }
         ],
         "business": [
             {
                 "data_type": "bigint",
                 "column_name": "review_count",
-                "column_description": ["The number of reviews for the business"]
+                "column_description": "The number of reviews for the business"
             },
             {
                 "data_type": "bigint",
                 "column_name": "is_open",
-                "column_description": ["Indicates whether the business is currently open or closed (1 for open, 0 for closed)"]
+                "column_description": "Indicates whether the business is currently open or closed (1 for open, 0 for closed)"
             },
             {
                 "data_type": "real",
                 "column_name": "rating",
-                "column_description": ["The average rating of the business"]
+                "column_description": "The average rating of the business"
             },
             {
                 "data_type": "bigint",
                 "column_name": "bid",
-                "column_description": ["The unique identifier for the business"]
+                "column_description": "The unique identifier for the business"
             },
             {
                 "data_type": "text",
                 "column_name": "city",
-                "column_description": ["The city where the business is located"]
+                "column_description": "The city where the business is located"
             },
             {
                 "data_type": "text",
                 "column_name": "latitude",
-                "column_description": ["The latitude of the business location"]
+                "column_description": "The latitude of the business location"
             },
             {
                 "data_type": "text",
                 "column_name": "longitude",
-                "column_description": ["The longitude of the business location"]
+                "column_description": "The longitude of the business location"
             },
             {
                 "data_type": "text",
                 "column_name": "state",
-                "column_description": ["The US state where the business is located. This is represented by two-letter state abbreviations."]
+                "column_description": "The US state where the business is located, represented by two-letter abbreviations (eg. 'CA', 'NV', 'NY', etc.)"
             },
             {
                 "data_type": "text",
                 "column_name": "business_id",
-                "column_description": ["The unique identifier for the business"]
+                "column_description": "The unique identifier for the business"
             },
             {
                 "data_type": "text",
                 "column_name": "name",
-                "column_description": ["The name of the business"]
+                "column_description": "The name of the business"
             },
             {
                 "data_type": "text",
                 "column_name": "full_address",
-                "column_description": ["The full address of the business"]
+                "column_description": "The full address of the business"
             }
         ],
         "category": [
             {
                 "data_type": "bigint",
                 "column_name": "id",
-                "column_description": ["Unique identifier for each category"]
+                "column_description": "Unique identifier for each category"
             },
             {
                 "data_type": "text",
                 "column_name": "business_id",
-                "column_description": ["Identifier for the business associated with the category"]
+                "column_description": "Identifier for the business associated with the category"
             },
             {
                 "data_type": "text",
                 "column_name": "category_name",
-                "column_description": ["Name of the category. Eg 'Bistro', 'Diner', 'Pizza'"]
+                "column_description": "Name of the category. Eg 'Bistro', 'Diner', 'Pizza'"
             }
         ],
         "neighbourhood": [
             {
                 "data_type": "bigint",
                 "column_name": "id",
-                "column_description": ["Unique identifier for each neighbourhood"]
+                "column_description": "Unique identifier for each neighbourhood"
             },
             {
                 "data_type": "text",
                 "column_name": "business_id",
-                "column_description": ["Identifier for each business in the neighbourhood"]
+                "column_description": "Identifier for each business in the neighbourhood"
             },
             {
                 "data_type": "text",
                 "column_name": "neighbourhood_name",
-                "column_description": ["Name of the neighbourhood where the business is located"]
+                "column_description": "Name of the neighbourhood where the business is located"
             }
         ]
-    },
-    "glossary": "This database contains information about reviews and tips left by users on different restaurants from different places.",
-    "table_descriptions": {
-        "tip": "The \"tip\" table contains information about tips created by users for businesses. It includes the year and month when the tip was created, a unique identifier for the tip, the user who created the tip, the business where the tip was created, and the text content of the tip. This table can be joined with other tables such as \"users\", \"business\", and \"review\" to gather additional information about the users, businesses, and reviews associated with the tips.",
-        "users": "The \"users\" table is used to store information about individual users. It contains a unique identifier for each user, a unique user ID assigned by the system, and the name of the user. This table can be joined with other tables such as \"tip\", \"review\", \"checkin\", \"business\" and \"neighbourhood\" to gather additional information about the users.",
-        "review": "The \"review\" table contains information about user reviews for businesses. It includes columns for the rating given by the user, the unique identifier for each review, the year and month in which the review was posted, the text of the review, the unique identifier for the business being reviewed, and the unique identifier for the user who posted the review. This table can be joined with the \"tip\", \"users\", \"checkin\", \"business\", \"category\", and \"neighbourhood\" tables.",
-        "checkin": "The \"checkin\" table is used to store information about the daily check-ins at businesses. It contains columns such as \"cid\" which is a unique identifier for the daily check-in count, \"count\" which represents the number of check-ins on a given day, \"business_id\" which is a unique identifier for the business where the check-in occurred, and \"day\" which indicates the day of the week when the check-ins occurred. This table can be joined with other tables such as \"tip\", \"users\", \"review\", \"business\", \"category\", \"neighbourhood\" to gather additional information related to the check-ins.",
-        "business": "The \"business\" table contains information about various businesses. It includes columns such as \"review_count\" (the number of reviews for the business), \"is_open\" (indicating whether the business is currently open or closed), \"rating\" (the average rating of the business), \"bid\" (the unique identifier for the business), \"city\" (the city where the business is located), \"latitude\" (the latitude of the business location), \"longitude\" (the longitude of the business location), \"state\" (the US state where the business is located), \"business_id\" (the unique identifier for the business), \"name\" (the name of the business), and \"full_address\" (the full address of the business).\n\nThis table can be joined with other tables such as \"tip\", \"users\", \"review\", \"checkin\", \"category\", and \"neighbourhood\" to gather additional information about the businesses.",
-        "category": "The \"category\" table is used to store information about different categories associated with businesses. It has a unique identifier for each category and also includes the business identifier and the name of the category. This table can be joined with other tables such as \"business\" to get additional information about the businesses associated with each category.",
-        "neighbourhood": "The \"neighbourhood\" table is used to store information about different neighbourhoods where businesses are located. It has a unique identifier for each neighbourhood and includes the name of the neighbourhood as well as the identifier for each business in that neighbourhood. This table can be joined with other tables such as \"tip\", \"users\", \"review\", \"checkin\", \"business\", \"category\", and \"neighbourhood\" to gather additional information about businesses and their activities within a specific neighbourhood."
     }
 }


### PR DESCRIPTION
Unnest column description to be a string. We copy the json from sql-eval directly, which also removes glossary and table_descriptions.