### PR TITLE
Add missing description to columns_ner

### DIFF
--- a/defog_data/supplementary.py
+++ b/defog_data/supplementary.py
@@ -179,7 +179,7 @@ columns_ner = {
         ],
         "LOC": [
             "lake.lake_name,text,The name of the lake",
-            "river.river_name,text,The name of the river",
+            "river.river_name,text,The name of the river. Names exclude the word 'river' e.g. 'Mississippi' instead of 'Mississippi River'",
             "mountain.mountain_name,text,The name of the mountain",
         ],
         "ORG": [],


### PR DESCRIPTION
We added the description to the json, but missed it in the columns_ner object in supplementary.py