### PR TITLE
Add broker and ewallet schema

### DIFF
--- a/defog_data/broker/broker.json
+++ b/defog_data/broker/broker.json
@@ -1,0 +1,228 @@
+{
+    "table_metadata": {
+      "sbCustomer": [
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbCustId",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(100)",
+          "column_name": "sbCustName",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(100)", 
+          "column_name": "sbCustEmail",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbCustPhone",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(200)",
+          "column_name": "sbCustAddress1",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(200)",
+          "column_name": "sbCustAddress2",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(50)",
+          "column_name": "sbCustCity",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbCustState",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(50)",
+          "column_name": "sbCustCountry",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbCustPostalCode",
+          "column_description": ""
+        },
+        {
+          "data_type": "date",
+          "column_name": "sbCustJoinDate",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbCustStatus",
+          "column_description": "possible values: active, inactive, suspended, closed"
+        }
+      ],
+      "sbTicker": [
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbTickerId",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(10)",
+          "column_name": "sbTickerSymbol",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(100)",
+          "column_name": "sbTickerName",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbTickerType",
+          "column_description": "possible values: stock, etf, mutualfund"
+        },
+        {
+          "data_type": "varchar(50)",
+          "column_name": "sbTickerExchange",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(10)",
+          "column_name": "sbTickerCurrency",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbTickerDb2x",
+          "column_description": "2 letter exchange code"
+        },
+        {
+          "data_type": "boolean",
+          "column_name": "sbTickerIsActive",
+          "column_description": ""
+        }
+      ],
+      "sbDailyPrice": [
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbDpTickerId",
+          "column_description": ""
+        },
+        {
+          "data_type": "date",
+          "column_name": "sbDpDate",
+          "column_description": ""
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbDpOpen",
+          "column_description": ""
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbDpHigh",
+          "column_description": ""
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbDpLow",
+          "column_description": ""
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbDpClose",
+          "column_description": ""
+        },
+        {
+          "data_type": "bigint",
+          "column_name": "sbDpVolume",
+          "column_description": ""
+        },
+        {
+          "data_type": "bigint",
+          "column_name": "sbDpEpochMs",
+          "column_description": "epoch milliseconds for timestamp"
+        },
+        {
+          "data_type": "varchar(50)",
+          "column_name": "sbDpSource",
+          "column_description": ""
+        }
+      ],
+      "sbTransaction": [
+        {
+          "data_type": "varchar(50)",
+          "column_name": "sbTxId",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)", 
+          "column_name": "sbTxCustId",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbTxTickerId",
+          "column_description": ""
+        },
+        {
+          "data_type": "timestamp",
+          "column_name": "sbTxDateTime",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(20)",
+          "column_name": "sbTxType",
+          "column_description": "possible values: buy, sell"
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbTxShares",
+          "column_description": ""
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbTxPrice",
+          "column_description": ""
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbTxAmount",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(10)",
+          "column_name": "sbTxCcy",
+          "column_description": "transaction currency"
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbTxTax",
+          "column_description": ""  
+        },
+        {
+          "data_type": "numeric(10,2)",
+          "column_name": "sbTxCommission",
+          "column_description": ""
+        },
+        {
+          "data_type": "varchar(10)",
+          "column_name": "sbTxKpx",
+          "column_description": "internal code"
+        },
+        {
+          "data_type": "varchar(25)",
+          "column_name": "sbTxDateStr",
+          "column_description": "date as string in yyyyMMdd HH:mm:ss format"
+        },
+        {
+          "data_type": "varchar(10)",
+          "column_name": "sbTxStatus",
+          "column_description": "possible values: success, fail, pending"
+        }
+      ]
+    },
+    "glossary": "- sbTicker can be joined to sbDailyPrice on sbTickerId\n- sbCustomer can be joined to sbTransaction on sbCustId\n- sbTicker can be joined to sbTransaction on sbTickerId\n- ADV (Average Daily Volume) for a ticker = AVG(sbDpVolume) from sbDailyPrice table for that ticker\n- ATH (All Time High) price for a ticker = MAX(sbDpHigh) from sbDailyPrice table for that ticker\n- ATP (Average Transaction Price) for a customer = SUM(sbTxAmount)/SUM(sbTxShares) from sbTransaction table for that customer\n- NCT (Net Commission Total) = SUM(sbTxCommission) from sbTransaction table"
+  }

--- a/defog_data/broker/broker.sql
+++ b/defog_data/broker/broker.sql
@@ -1,0 +1,157 @@
+
+-- Dimension tables
+CREATE TABLE sbCustomer (
+  sbCustId varchar(20) PRIMARY KEY,
+  sbCustName varchar(100) NOT NULL,
+  sbCustEmail varchar(100) NOT NULL,
+  sbCustPhone varchar(20),
+  sbCustAddress1 varchar(200),
+  sbCustAddress2 varchar(200),
+  sbCustCity varchar(50),
+  sbCustState varchar(20),
+  sbCustCountry varchar(50),
+  sbCustPostalCode varchar(20),
+  sbCustJoinDate date NOT NULL,
+  sbCustStatus varchar(20) NOT NULL -- possible values: active, inactive, suspended, closed
+);
+
+CREATE TABLE sbTicker (
+  sbTickerId varchar(20) PRIMARY KEY,
+  sbTickerSymbol varchar(10) NOT NULL,
+  sbTickerName varchar(100) NOT NULL, 
+  sbTickerType varchar(20) NOT NULL, -- possible values: stock, etf, mutualfund
+  sbTickerExchange varchar(50) NOT NULL,
+  sbTickerCurrency varchar(10) NOT NULL,
+  sbTickerDb2x varchar(20), -- 2 letter exchange code
+  sbTickerIsActive boolean NOT NULL
+);
+
+-- Fact tables  
+CREATE TABLE sbDailyPrice (
+  sbDpTickerId varchar(20) NOT NULL,
+  sbDpDate date NOT NULL,
+  sbDpOpen numeric(10,2) NOT NULL,
+  sbDpHigh numeric(10,2) NOT NULL, 
+  sbDpLow numeric(10,2) NOT NULL,
+  sbDpClose numeric(10,2) NOT NULL,
+  sbDpVolume bigint NOT NULL,
+  sbDpEpochMs bigint NOT NULL, -- epoch milliseconds for timestamp
+  sbDpSource varchar(50)
+);
+
+CREATE TABLE sbTransaction (
+  sbTxId varchar(50) PRIMARY KEY,
+  sbTxCustId varchar(20) NOT NULL,
+  sbTxTickerId varchar(20) NOT NULL,  
+  sbTxDateTime timestamp NOT NULL,
+  sbTxType varchar(20) NOT NULL, -- possible values: buy, sell
+  sbTxShares numeric(10,2) NOT NULL,
+  sbTxPrice numeric(10,2) NOT NULL,
+  sbTxAmount numeric(10,2) NOT NULL,
+  sbTxCcy varchar(10), -- transaction currency  
+  sbTxTax numeric(10,2) NOT NULL,
+  sbTxCommission numeric(10,2) NOT NULL,
+  sbTxKpx varchar(10), -- internal code
+  sbTxDateStr varchar(25), -- date as string in yyyyMMdd HH:mm:ss format
+  sbTxStatus varchar(10) NOT NULL -- possible values: success, fail, pending
+);
+
+
+-- sbCustomer
+INSERT INTO sbCustomer (sbCustId, sbCustName, sbCustEmail, sbCustPhone, sbCustAddress1, sbCustCity, sbCustState, sbCustCountry, sbCustPostalCode, sbCustJoinDate, sbCustStatus) VALUES
+('C001', 'John Doe', 'john.doe@email.com', '555-123-4567', '123 Main St', 'Anytown', 'CA', 'USA', '90001', '2020-01-01', 'active'),
+('C002', 'Jane Smith', 'jane.smith@email.com', '555-987-6543', '456 Oak Rd', 'Someville', 'NY', 'USA', '10002', '2019-03-15', 'active'),
+('C003', 'Bob Johnson', 'bob.johnson@email.com', '555-246-8135', '789 Pine Ave', 'Mytown', 'TX', 'USA', '75000', '2022-06-01', 'inactive'),
+('C004', 'Samantha Lee', 'samantha.lee@email.com', '555-135-7902', '246 Elm St', 'Yourtown', 'CA', 'USA', '92101', '2018-09-22', 'suspended'),
+('C005', 'Michael Chen', 'michael.chen@email.com', '555-864-2319', '159 Cedar Ln', 'Anothertown', 'FL', 'USA', '33101', '2021-02-28', 'active'),
+('C006', 'Emily Davis', 'emily.davis@email.com', '555-753-1904', '753 Maple Dr', 'Mytown', 'TX', 'USA', '75000', '2020-07-15', 'active'), 
+('C007', 'David Kim', 'david.kim@email.com', '555-370-2648', '864 Oak St', 'Anothertown', 'FL', 'USA', '33101', '2022-11-05', 'active'),
+('C008', 'Sarah Nguyen', 'sarah.nguyen@email.com', '555-623-7419', '951 Pine Rd', 'Yourtown', 'CA', 'USA', '92101', '2019-04-01', 'closed'),
+('C009', 'William Garcia', 'william.garcia@email.com', '555-148-5326', '258 Elm Ave', 'Anytown', 'CA', 'USA', '90001', '2021-08-22', 'active'),
+('C010', 'Jessica Hernandez', 'jessica.hernandez@email.com', '555-963-8520', '147 Cedar Blvd', 'Someville', 'NY', 'USA', '10002', '2020-03-10', 'inactive');
+
+-- sbTicker  
+INSERT INTO sbTicker (sbTickerId, sbTickerSymbol, sbTickerName, sbTickerType, sbTickerExchange, sbTickerCurrency, sbTickerDb2x, sbTickerIsActive) VALUES
+('T001', 'AAPL', 'Apple Inc.', 'stock', 'NASDAQ', 'USD', 'NQ', true),
+('T002', 'MSFT', 'Microsoft Corporation', 'stock', 'NASDAQ', 'USD', 'NQ', true),
+('T003', 'AMZN', 'Amazon.com, Inc.', 'stock', 'NASDAQ', 'USD', 'NQ', true),
+('T004', 'TSLA', 'Tesla, Inc.', 'stock', 'NASDAQ', 'USD', 'NQ', true),
+('T005', 'GOOGL', 'Alphabet Inc.', 'stock', 'NASDAQ', 'USD', 'NQ', true),
+('T006', 'FB', 'Meta Platforms, Inc.', 'stock', 'NASDAQ', 'USD', 'NQ', true),
+('T007', 'BRK.B', 'Berkshire Hathaway Inc.', 'stock', 'NYSE', 'USD', 'NY', true),
+('T008', 'JPM', 'JPMorgan Chase & Co.', 'stock', 'NYSE', 'USD', 'NY', true),
+('T009', 'V', 'Visa Inc.', 'stock', 'NYSE', 'USD', 'NY', true),
+('T010', 'PG', 'Procter & Gamble Company', 'stock', 'NYSE', 'USD', 'NY', true),
+('T011', 'SPY', 'SPDR S&P 500 ETF Trust', 'etf', 'NYSE Arca', 'USD', 'NX', true),
+('T012', 'QQQ', 'Invesco QQQ Trust', 'etf', 'NASDAQ', 'USD', 'NQ', true),
+('T013', 'VTI', 'Vanguard Total Stock Market ETF', 'etf', 'NYSE Arca', 'USD', 'NX', true), 
+('T014', 'VXUS', 'Vanguard Total International Stock ETF', 'etf', 'NASDAQ', 'USD', 'NQ', true),
+('T015', 'VFINX', 'Vanguard 500 Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true),
+('T016', 'VTSAX', 'Vanguard Total Stock Market Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true),  
+('T017', 'VIGAX', 'Vanguard Growth Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true);
+
+-- sbDailyPrice
+INSERT INTO sbDailyPrice (sbDpTickerId, sbDpDate, sbDpOpen, sbDpHigh, sbDpLow, sbDpClose, sbDpVolume, sbDpEpochMs, sbDpSource) VALUES
+('T001', '2023-04-01', 150.00, 152.50, 148.75, 151.25, 75000000, 1680336000000, 'NYSE'),
+('T002', '2023-04-01', 280.00, 282.75, 279.50, 281.00, 35000000, 1680336000000, 'NASDAQ'),
+('T003', '2023-04-01', 3200.00, 3225.00, 3180.00, 3210.00, 4000000, 1680336000000, 'NASDAQ'),
+('T004', '2023-04-01', 180.00, 185.00, 178.50, 184.25, 20000000, 1680336000000, 'NASDAQ'),
+('T005', '2023-04-01', 2500.00, 2525.00, 2475.00, 2510.00, 1500000, 1680336000000, 'NASDAQ'),
+('T006', '2023-04-01', 200.00, 205.00, 198.00, 202.50, 15000000, 1680336000000, 'NASDAQ'),
+('T007', '2023-04-01', 400000.00, 402500.00, 398000.00, 401000.00, 10000, 1680336000000, 'NYSE'),
+('T008', '2023-04-01', 130.00, 132.50, 128.75, 131.00, 12000000, 1680336000000, 'NYSE'),
+('T009', '2023-04-01', 220.00, 222.50, 218.00, 221.00, 8000000, 1680336000000, 'NYSE'),
+('T010', '2023-04-01', 140.00, 142.00, 139.00, 141.50, 6000000, 1680336000000, 'NYSE'),
+('T001', '2023-04-02', 151.50, 153.00, 150.00, 152.00, 70000000, 1680422400000, 'NYSE'),
+('T002', '2023-04-02', 281.25, 283.50, 280.00, 282.75, 32000000, 1680422400000, 'NASDAQ'),
+('T003', '2023-04-02', 3212.00, 3230.00, 3200.00, 3225.00, 3800000, 1680422400000, 'NASDAQ'),
+('T004', '2023-04-02', 184.50, 187.00, 183.00, 186.00, 18000000, 1680422400000, 'NASDAQ'),
+('T005', '2023-04-02', 2512.00, 2530.00, 2500.00, 2520.00, 1400000, 1680422400000, 'NASDAQ'),
+('T006', '2023-04-02', 203.00, 206.50, 201.00, 205.00, 14000000, 1680422400000, 'NASDAQ'),
+('T007', '2023-04-02', 401500.00, 403000.00, 400000.00, 402000.00, 9500, 1680422400000, 'NYSE'),
+('T008', '2023-04-02', 131.25, 133.00, 130.00, 132.50, 11000000, 1680422400000, 'NYSE'),
+('T009', '2023-04-02', 221.50, 223.00, 220.00, 222.00, 7500000, 1680422400000, 'NYSE'),
+('T010', '2023-04-02', 141.75, 143.00, 140.50, 142.25, 5500000, 1680422400000, 'NYSE'),
+('T001', '2023-04-03', 152.25, 154.00, 151.00, 153.50, 65000000, 1680508800000, 'NYSE'),
+('T002', '2023-04-03', 283.00, 285.00, 281.50, 284.00, 30000000, 1680508800000, 'NASDAQ'),
+('T003', '2023-04-03', 3227.00, 3240.00, 3220.00, 3235.00, 3600000, 1680508800000, 'NASDAQ'),
+('T004', '2023-04-03', 186.25, 188.50, 185.00, 187.75, 16000000, 1680508800000, 'NASDAQ'),
+('T005', '2023-04-03', 2522.00, 2540.00, 2515.00, 2535.00, 1300000, 1680508800000, 'NASDAQ'),  
+('T006', '2023-04-03', 205.50, 208.00, 203.50, 207.00, 13000000, 1680508800000, 'NASDAQ'),
+('T007', '2023-04-03', 402500.00, 404000.00, 401000.00, 403500.00, 9000, 1680508800000, 'NYSE'),
+('T008', '2023-04-03', 132.75, 134.50, 131.50, 133.75, 10000000, 1680508800000, 'NYSE'),
+('T009', '2023-04-03', 222.25, 224.00, 221.00, 223.50, 7000000, 1680508800000, 'NYSE'),
+('T010', '2023-04-03', 142.50, 144.00, 141.50, 143.25, 5000000, 1680508800000, 'NYSE');
+
+-- sbTransaction
+INSERT INTO sbTransaction (sbTxId, sbTxCustId, sbTxTickerId, sbTxDateTime, sbTxType, sbTxShares, sbTxPrice, sbTxAmount, sbTxCcy, sbTxTax, sbTxCommission, sbTxKpx, sbTxDateStr, sbTxStatus) VALUES
+('TX001', 'C001', 'T001', '2023-04-01 09:30:00', 'buy', 100, 150.00, 15000.00, 'USD', 75.00, 10.00, 'KP001', '20230401 09:30:00', 'success'),
+('TX002', 'C002', 'T002', '2023-04-01 10:15:00', 'sell', 50, 280.00, 14000.00, 'USD', 70.00, 10.00, 'KP002', '20230401 10:15:00', 'success'),
+('TX003', 'C003', 'T003', '2023-04-01 11:00:00', 'buy', 10, 3200.00, 32000.00, 'USD', 160.00, 20.00, 'KP003', '20230401 11:00:00', 'success'),
+('TX004', 'C004', 'T004', '2023-04-01 11:45:00', 'sell', 25, 180.00, 4500.00, 'USD', 22.50, 5.00, 'KP004', '20230401 11:45:00', 'success'),
+('TX005', 'C005', 'T005', '2023-04-01 12:30:00', 'buy', 5, 2500.00, 12500.00, 'USD', 62.50, 15.00, 'KP005', '20230401 12:30:00', 'success'),
+('TX006', 'C006', 'T006', '2023-04-01 13:15:00', 'sell', 75, 200.00, 15000.00, 'USD', 75.00, 10.00, 'KP006', '20230401 13:15:00', 'success'),
+('TX007', 'C007', 'T007', '2023-04-01 14:00:00', 'buy', 1, 400000.00, 400000.00, 'USD', 2000.00, 100.00, 'KP007', '20230401 14:00:00', 'success'),
+('TX008', 'C008', 'T008', '2023-04-01 14:45:00', 'sell', 100, 130.00, 13000.00, 'USD', 65.00, 10.00, 'KP008', '20230401 14:45:00', 'success'),
+('TX009', 'C009', 'T009', '2023-04-01 15:30:00', 'buy', 50, 220.00, 11000.00, 'USD', 55.00, 10.00, 'KP009', '20230401 15:30:00', 'success'),
+('TX010', 'C010', 'T010', '2023-04-01 16:15:00', 'sell', 80, 140.00, 11200.00, 'USD', 56.00, 10.00, 'KP010', '20230401 16:15:00', 'success'),
+('TX011', 'C001', 'T001', '2023-04-02 09:30:00', 'sell', 50, 151.50, 7575.00, 'USD', 37.88, 5.00, 'KP011', '20230402 09:30:00', 'success'),
+('TX012', 'C002', 'T002', '2023-04-02 10:15:00', 'buy', 30, 281.25, 8437.50, 'USD', 42.19, 7.50, 'KP012', '20230402 10:15:00', 'success'),
+('TX013', 'C003', 'T003', '2023-04-02 11:00:00', 'sell', 5, 3212.00, 16060.00, 'USD', 80.30, 15.00, 'KP013', '20230402 11:00:00', 'success'), 
+('TX014', 'C004', 'T004', '2023-04-02 11:45:00', 'buy', 15, 184.50, 2767.50, 'USD', 13.84, 5.00, 'KP014', '20230402 11:45:00', 'success'),
+('TX015', 'C005', 'T005', '2023-04-02 12:30:00', 'sell', 2, 2512.00, 5024.00, 'USD', 25.12, 10.00, 'KP015', '20230402 12:30:00', 'success'),
+('TX016', 'C006', 'T006', '2023-04-02 13:15:00', 'buy', 50, 203.00, 10150.00, 'USD', 50.75, 10.00, 'KP016', '20230402 13:15:00', 'success'),  
+('TX017', 'C007', 'T007', '2023-04-02 14:00:00', 'sell', 1, 401500.00, 401500.00, 'USD', 2007.50, 100.00, 'KP017', '20230402 14:00:00', 'success'),
+('TX018', 'C008', 'T008', '2023-04-02 14:45:00', 'buy', 75, 131.25, 9843.75, 'USD', 49.22, 7.50, 'KP018', '20230402 14:45:00', 'success'),
+('TX019', 'C009', 'T009', '2023-04-02 15:30:00', 'sell', 25, 221.50, 5537.50, 'USD', 27.69, 5.00, 'KP019', '20230402 15:30:00', 'success'),
+('TX020', 'C010', 'T010', '2023-04-02 16:15:00', 'buy', 60, 141.75, 8505.00, 'USD', 42.53, 7.50, 'KP020', '20230402 16:15:00', 'success'),
+('TX021', 'C001', 'T001', '2023-04-03 09:30:00', 'buy', 75, 152.25, 11418.75, 'USD', 57.09, 10.00, 'KP021', '20230403 09:30:00', 'success'),
+('TX022', 'C002', 'T002', '2023-04-03 10:15:00', 'sell', 40, 283.00, 11320.00, 'USD', 56.60, 10.00, 'KP022', '20230403 10:15:00', 'success'),  
+('TX023', 'C003', 'T003', '2023-04-03 11:00:00', 'buy', 8, 3227.00, 25816.00, 'USD', 129.08, 20.00, 'KP023', '20230403 11:00:00', 'success'),
+('TX024', 'C004', 'T004', '2023-04-03 11:45:00', 'sell', 20, 186.25, 3725.00, 'USD', 18.63, 5.00, 'KP024', '20230403 11:45:00', 'success'),
+('TX025', 'C005', 'T005', '2023-04-03 12:30:00', 'buy', 3, 2522.00, 7566.00, 'USD', 37.83, 15.00, 'KP025', '20230403 12:30:00', 'success'),
+('TX026', 'C006', 'T006', '2023-04-03 13:15:00', 'sell', 60, 205.50, 12330.00, 'USD', 61.65, 10.00, 'KP026', '20230403 13:15:00', 'success'),
+('TX027', 'C007', 'T007', '2023-04-03 14:00:00', 'buy', 1, 402500.00, 402500.00, 'USD', 2012.50, 100.00, 'KP027', '20230403 14:00:00', 'success'),  
+('TX028', 'C008', 'T008', '2023-04-03 14:45:00', 'sell', 90, 132.75, 11947.50, 'USD', 59.74, 7.50, 'KP028', '20230403 14:45:00', 'success'),
+('TX029', 'C009', 'T009', '2023-04-03 15:30:00', 'buy', 40, 222.25, 8890.00, 'USD', 44.45, 10.00, 'KP029', '20230403 15:30:00', 'success'),
+('TX030', 'C010', 'T010', '2023-04-03 16:15:00', 'sell', 70, 142.50, 9975.00, 'USD', 49.88, 10.00, 'KP030', '20230403 16:15:00', 'success');

--- a/defog_data/car_dealership/car_dealership.json
+++ b/defog_data/car_dealership/car_dealership.json
@@ -61,37 +61,37 @@
         {
           "data_type": "SERIAL",
           "column_name": "id",
-          "column_description": "Primary key for the salespersons table"
+          "column_description": "Unique identifier for each salesperson"
         },
         {
           "data_type": "TEXT",
           "column_name": "first_name",
-          "column_description": "First name of the salesperson"
+          "column_description": ""
         },
         {
           "data_type": "TEXT",
           "column_name": "last_name",
-          "column_description": "Last name of the salesperson"
+          "column_description": ""
         },
         {
           "data_type": "VARCHAR(255)",
           "column_name": "email",
-          "column_description": "Email address of the salesperson"
+          "column_description": ""
         },
         {
           "data_type": "VARCHAR(20)",
           "column_name": "phone",
-          "column_description": "Phone number of the salesperson"
+          "column_description": ""
         },
         {
           "data_type": "DATE",
           "column_name": "hire_date",
-          "column_description": "Date when the salesperson was hired"
+          "column_description": ""
         },
         {
           "data_type": "DATE",
           "column_name": "termination_date",
-          "column_description": "Date when the salesperson's employment was terminated"
+          "column_description": ""
         },
         {
           "data_type": "TIMESTAMP",
@@ -108,42 +108,42 @@
         {
           "data_type": "TEXT",
           "column_name": "first_name",
-          "column_description": "First name of the customer"
+          "column_description": ""
         },
         {
           "data_type": "TEXT",
           "column_name": "last_name",
-          "column_description": "Last name of the customer"
+          "column_description": ""
         },
         {
           "data_type": "VARCHAR(255)",
           "column_name": "email",
-          "column_description": "Email address of the customer"
+          "column_description": ""
         },
         {
           "data_type": "VARCHAR(20)",
           "column_name": "phone",
-          "column_description": "Phone number of the customer"
+          "column_description": ""
         },
         {
           "data_type": "TEXT",
           "column_name": "address",
-          "column_description": "Address of the customer"
+          "column_description": ""
         },
         {
           "data_type": "TEXT",
           "column_name": "city",
-          "column_description": "City of the customer"
+          "column_description": ""
         },
         {
           "data_type": "TEXT",
           "column_name": "state",
-          "column_description": "State of the customer"
+          "column_description": ""
         },
         {
           "data_type": "VARCHAR(10)",
           "column_name": "zip_code",
-          "column_description": "ZIP code of the customer"
+          "column_description": ""
         },
         {
           "data_type": "TIMESTAMP",
@@ -155,7 +155,7 @@
         {
           "data_type": "SERIAL",
           "column_name": "id",
-          "column_description": "Primary key for the sales table"
+          "column_description": "Primary key that uniquely identifies each sale"
         },
         {
           "data_type": "INTEGER",
@@ -219,7 +219,7 @@
         {
           "data_type": "SERIAL",
           "column_name": "id",
-          "column_description": "Primary key for the payments_received table"
+          "column_description": "Uniquely identifies each payment received record"
         },
         {
           "data_type": "INTEGER",
@@ -229,12 +229,12 @@
         {
           "data_type": "DATE",
           "column_name": "payment_date",
-          "column_description": "Date when the payment was received"
+          "column_description": "Date when the payment was received. Can take place after the sale date, or in installments."
         },
         {
           "data_type": "NUMERIC(10, 2)",
           "column_name": "payment_amount",
-          "column_description": "Amount of the payment received"
+          "column_description": "Amount of the payment received. Can be less than the sale price if the payment is made in installments."
         },
         {
           "data_type": "TEXT",

--- a/defog_data/ewallet/ewallet.json
+++ b/defog_data/ewallet/ewallet.json
@@ -1,0 +1,503 @@
+{
+    "table_metadata": {
+      "consumer_div.users": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "uid",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "username",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(100)",
+          "column_name": "email",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "phone_number",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "created_at",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "last_login_at",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "user_type",
+          "column_description": "possible values: individual, business, admin"
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "status",
+          "column_description": "possible values: active, inactive, suspended, deleted"
+        },
+        {
+          "data_type": "VARCHAR(2)",
+          "column_name": "country",
+          "column_description": "2-letter country code"
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "address_billing",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT", 
+          "column_name": "address_delivery",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "kyc_status",
+          "column_description": "possible values: pending, approved, rejected"
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "kyc_verified_at",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.merchants": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "mid",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(100)",
+          "column_name": "name",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "description", 
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(200)",
+          "column_name": "website_url",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(200)", 
+          "column_name": "logo_url",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "created_at",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(2)",
+          "column_name": "country",
+          "column_description": "2-letter country code"
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "state",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "city",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "postal_code",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "address",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "status",
+          "column_description": "possible values: active, inactive, suspended"
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "category",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)", 
+          "column_name": "sub_category",
+          "column_description": ""
+        },
+        {
+          "data_type": "INT",
+          "column_name": "mcc",
+          "column_description": "Merchant Category Code"
+        },
+        {
+          "data_type": "VARCHAR(100)",
+          "column_name": "contact_name",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(100)",
+          "column_name": "contact_email",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "contact_phone",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.coupons": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "cid",
+          "column_description": ""
+        },
+        {
+          "data_type": "BIGINT",
+          "column_name": "merchant_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "code",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "description",
+          "column_description": ""
+        },
+        {
+          "data_type": "DATE",
+          "column_name": "start_date",
+          "column_description": ""
+        },
+        {
+          "data_type": "DATE",
+          "column_name": "end_date",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "discount_type",
+          "column_description": "possible values: percentage, fixed_amount"
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "discount_value",
+          "column_description": ""
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "min_purchase_amount",
+          "column_description": ""
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "max_discount_amount",
+          "column_description": ""
+        },
+        {
+          "data_type": "INT",
+          "column_name": "redemption_limit",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "status",
+          "column_description": "possible values: active, inactive, expired"
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "created_at",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "updated_at",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.wallet_transactions_daily": [
+        {
+          "data_type": "SERIAL",
+          "column_name": "txid",
+          "column_description": ""
+        },
+        {
+          "data_type": "BIGINT",
+          "column_name": "sender_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "INT",
+          "column_name": "sender_type",
+          "column_description": "0 for user, 1 for merchant"
+        },
+        {
+          "data_type": "BIGINT",
+          "column_name": "receiver_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "INT",
+          "column_name": "receiver_type",
+          "column_description": "0 for user, 1 for merchant"
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "amount",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "status",
+          "column_description": "possible values: pending, success, failed, refunded"
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "type",
+          "column_description": "possible values: credit, debit"
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "description",
+          "column_description": ""
+        },
+        {
+          "data_type": "BIGINT",
+          "column_name": "coupon_id",
+          "column_description": "NULL if transaction doesn't involve a coupon"
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "created_at",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "completed_at",
+          "column_description": "NULL if failed"
+        },
+        {
+          "data_type": "VARCHAR(36)",
+          "column_name": "transaction_ref",
+          "column_description": "randomly generated uuid4 for users' reference"
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "gateway_name",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "gateway_ref",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "device_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "ip_address",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "user_agent",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.wallet_user_balance_daily": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "user_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "balance",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "updated_at",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.wallet_merchant_balance_daily": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "merchant_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "balance",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "updated_at",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.notifications": [
+        {
+          "data_type": "SERIAL",
+          "column_name": "id",
+          "column_description": ""
+        },
+        {
+          "data_type": "INT",
+          "column_name": "user_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "message",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(50)",
+          "column_name": "type",
+          "column_description": "possible values: transaction, promotion, security, general"
+        },
+        {
+          "data_type": "VARCHAR(20)",
+          "column_name": "status",
+          "column_description": "possible values: unread, read, archived"
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "created_at",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "read_at",
+          "column_description": "NULL if not read"
+        },
+        {
+          "data_type": "VARCHAR(10)",
+          "column_name": "device_type",
+          "column_description": "possible values: mobile_app, web_app, email, sms"
+        },
+        {
+          "data_type": "VARCHAR(36)",
+          "column_name": "device_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "action_url",
+          "column_description": "can be external https or deeplink url within the app"
+        }
+      ],
+      "consumer_div.user_sessions": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "user_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "session_start_ts",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "session_end_ts",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(10)",
+          "column_name": "device_type",
+          "column_description": "possible values: mobile_app, web_app, email, sms"
+        },
+        {
+          "data_type": "VARCHAR(36)",
+          "column_name": "device_id",
+          "column_description": ""
+        }
+      ],
+      "consumer_div.user_setting_snapshot": [
+        {
+          "data_type": "BIGINT",
+          "column_name": "user_id",
+          "column_description": ""
+        },
+        {
+          "data_type": "DATE",
+          "column_name": "snapshot_date",
+          "column_description": ""
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "tx_limit_daily",
+          "column_description": ""
+        },
+        {
+          "data_type": "DECIMAL(10,2)",
+          "column_name": "tx_limit_monthly",
+          "column_description": ""
+        },
+        {
+          "data_type": "INTEGER",
+          "column_name": "membership_status",
+          "column_description": "0 for bronze, 1 for silver, 2 for gold, 3 for platinum, 4 for VIP"
+        },
+        {
+          "data_type": "VARCHAR(255)",
+          "column_name": "password_hash",
+          "column_description": ""
+        },
+        {
+          "data_type": "VARCHAR(255)",
+          "column_name": "api_key",
+          "column_description": ""
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "verified_devices",
+          "column_description": "comma separated list of device ids"
+        },
+        {
+          "data_type": "TEXT",
+          "column_name": "verified_ips",
+          "column_description": "comma separated list of IP addresses"
+        },
+        {
+          "data_type": "BOOLEAN",
+          "column_name": "mfa_enabled",
+          "column_description": ""
+        },
+        {
+          "data_type": "BOOLEAN",
+          "column_name": "marketing_opt_in",
+          "column_description": ""
+        },
+        {
+          "data_type": "TIMESTAMP",
+          "column_name": "created_at",
+          "column_description": ""
+        }
+      ]
+    },
+    "glossary": "- sender_id and receiver_id can be joined with either users.uid or merchants.mid depending on the sender_type\n- if a user applied a coupon to a purchase, there will be 2 rows in wallet_transactions_daily:\n  - 1st row where coupon_id is NULL, amount = purchase value \n  - 2nd row where coupon_id is NOT NULL, amount = coupon value applied\n  - the sender and receiver id will be the same for both rows, but they will have different txid's \n- coupons.code and wallet_transactions_daily.gateway_name should be matched case insensitively\n- Total Transaction Volume (TTV) = SUM(wallet_transactions_daily.amount)\n- Total Coupon Discount Redeemed (TCDR) = SUM(wallet_transactions_daily.amount) WHERE coupon_id IS NOT NULL\n- Session Density = COUNT(user_sessions.user_id) / COUNT(DISTINCT user_sessions.user_id)\n- Active Merchants Percentage (APM) = COUNT(DISTINCT CASE WHEN sender_type = 1 THEN wallet_transactions_daily.sender_id WHEN receiver_type = 1 THEN wallet_transactions_daily.receiver_id ELSE NULL END) / COUNT(DISTINCT merchants.mid)"
+}

--- a/defog_data/ewallet/ewallet.sql
+++ b/defog_data/ewallet/ewallet.sql
@@ -1,0 +1,270 @@
+CREATE SCHEMA IF NOT EXISTS consumer_div;
+
+CREATE TABLE consumer_div.users (
+  uid BIGINT PRIMARY KEY,
+  username VARCHAR(50) NOT NULL,
+  email VARCHAR(100) NOT NULL,
+  phone_number VARCHAR(20),
+  created_at TIMESTAMP NOT NULL,
+  last_login_at TIMESTAMP,
+  user_type VARCHAR(20) NOT NULL, -- possible values: individual, business, admin
+  status VARCHAR(20) NOT NULL, -- possible values: active, inactive, suspended, deleted
+  country VARCHAR(2), -- 2-letter country code
+  address_billing TEXT,
+  address_delivery TEXT,
+  kyc_status VARCHAR(20), -- possible values: pending, approved, rejected
+  kyc_verified_at TIMESTAMP
+);
+
+CREATE TABLE consumer_div.merchants (
+  mid BIGINT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  description TEXT,
+  website_url VARCHAR(200),
+  logo_url VARCHAR(200),
+  created_at TIMESTAMP NOT NULL,
+  country VARCHAR(2), -- 2-letter country code
+  state VARCHAR(50),
+  city VARCHAR(50),
+  postal_code VARCHAR(20),
+  address TEXT,
+  status VARCHAR(20) NOT NULL, -- possible values: active, inactive, suspended
+  category VARCHAR(50),
+  sub_category VARCHAR(50),
+  mcc INT, -- Merchant Category Code
+  contact_name VARCHAR(100),
+  contact_email VARCHAR(100),
+  contact_phone VARCHAR(20)
+);
+
+CREATE TABLE consumer_div.coupons (
+  cid BIGINT PRIMARY KEY,
+  merchant_id BIGINT NOT NULL REFERENCES consumer_div.merchants(mid),
+  code VARCHAR(20) NOT NULL,
+  description TEXT,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  discount_type VARCHAR(20) NOT NULL, -- possible values: percentage, fixed_amount
+  discount_value DECIMAL(10,2) NOT NULL,
+  min_purchase_amount DECIMAL(10,2),
+  max_discount_amount DECIMAL(10,2),
+  redemption_limit INT,
+  status VARCHAR(20) NOT NULL, -- possible values: active, inactive, expired
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP
+);
+
+-- Fact Tables --
+
+CREATE TABLE consumer_div.wallet_transactions_daily (
+  txid SERIAL PRIMARY KEY,
+  sender_id BIGINT NOT NULL,
+  sender_type INT NOT NULL, -- 0 for user, 1 for merchant
+  receiver_id BIGINT NOT NULL,
+  receiver_type INT NOT NULL, -- 0 for user, 1 for merchant
+  amount DECIMAL(10,2) NOT NULL,
+  status VARCHAR(20) NOT NULL, -- possible values: pending, success, failed, refunded
+  type VARCHAR(20) NOT NULL, -- possible values: credit, debit
+  description TEXT,
+  coupon_id BIGINT, -- NULL if transaction doesn't involve a coupon
+  created_at TIMESTAMP NOT NULL,
+  completed_at TIMESTAMP, -- NULL if failed
+  transaction_ref VARCHAR(36) NOT NULL, -- randomly generated uuid4 for users' reference
+  gateway_name VARCHAR(50),
+  gateway_ref VARCHAR(50),
+  device_id VARCHAR(50),
+  ip_address VARCHAR(50),
+  user_agent TEXT
+);
+
+CREATE TABLE consumer_div.wallet_user_balance_daily (
+  user_id BIGINT PRIMARY KEY,
+  balance DECIMAL(10,2) NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE consumer_div.wallet_merchant_balance_daily (
+  merchant_id BIGINT PRIMARY KEY,
+  balance DECIMAL(10,2) NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE consumer_div.notifications (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES consumer_div.users(uid),
+  message TEXT NOT NULL,
+  type VARCHAR(50) NOT NULL, -- possible values: transaction, promotion, security, general 
+  status VARCHAR(20) NOT NULL, -- possible values: unread, read, archived
+  created_at TIMESTAMP NOT NULL,
+  read_at TIMESTAMP, -- NULL if not read
+  device_type VARCHAR(10), -- possible values: mobile_app, web_app, email, sms
+  device_id VARCHAR(36),
+  action_url TEXT -- can be external https or deeplink url within the app
+);  
+
+CREATE TABLE consumer_div.user_sessions (
+  user_id BIGINT NOT NULL,
+  session_start_ts TIMESTAMP NOT NULL,
+  session_end_ts TIMESTAMP,
+  device_type VARCHAR(10), -- possible values: mobile_app, web_app, email, sms
+  device_id VARCHAR(36)
+);
+
+CREATE TABLE consumer_div.user_setting_snapshot (
+  user_id BIGINT NOT NULL,
+  snapshot_date DATE NOT NULL,
+  tx_limit_daily DECIMAL(10,2),
+  tx_limit_monthly DECIMAL(10,2),
+  membership_status INTEGER, -- 0 for bronze, 1 for silver, 2 for gold, 3 for platinum, 4 for VIP
+  password_hash VARCHAR(255),
+  api_key VARCHAR(255),
+  verified_devices TEXT, -- comma separated list of device ids
+  verified_ips TEXT, -- comma separated list of IP addresses
+  mfa_enabled BOOLEAN,
+  marketing_opt_in BOOLEAN,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, snapshot_date)
+);
+
+-- users
+INSERT INTO consumer_div.users (uid, username, email, phone_number, created_at, user_type, status, country, address_billing, address_delivery, kyc_status) 
+VALUES 
+  (1, 'john_doe', 'john.doe@email.com', '+1234567890', '2022-01-01 10:00:00', 'individual', 'active', 'US', '123 Main St, Anytown US 12345', '123 Main St, Anytown US 12345', 'approved'),
+  (2, 'jane_smith', 'jane.smith@email.com', '+9876543210', '2022-02-15 14:30:00', 'individual', 'active', 'CA', '456 Oak Rd, Toronto ON M1M2M2', '456 Oak Rd, Toronto ON M1M2M2', 'approved'), 
+  (3, 'bizuser', 'contact@business.co', '+1234509876', '2021-06-01 09:15:00', 'business', 'active', 'FR', '12 Rue Baptiste, Paris 75001', NULL, 'approved'),
+  (4, 'david_miller', 'dave@personal.email', '+4477788899', '2023-03-20 18:45:00', 'individual', 'inactive', 'GB', '25 London Road, Manchester M12 4XY', '25 London Road, Manchester M12 4XY', 'pending'),
+  (5, 'emily_wilson', 'emily.w@gmail.com', '+8091017161', '2021-11-03 22:10:00', 'individual', 'suspended', 'AU', '72 Collins St, Melbourne VIC 3000', '19 Smith St, Brunswick VIC 3056', 'rejected'),
+  (6, 'techcorp', 'orders@techcorp.com', '+14165558888', '2018-05-20 11:35:00', 'business', 'active', 'US', '33 Technology Dr, Silicon Valley CA 94301', NULL, 'approved'),
+  (7, 'shopsmart', 'customerserv@shopsmart.biz', '+6585771234', '2020-09-15 06:25:00', 'business', 'inactive', 'SG', '888 Orchard Rd, #05-000, Singapore 238801', NULL, 'approved'),
+  (8, 'michael_brown', 'mike.brown@outlook.com', '+3912378624', '2019-07-22 16:40:00', 'individual', 'active', 'DE', 'Heidestr 17, Berlin 10557', 'Heidestr 17, Berlin 10557', 'approved'),
+  (9, 'alex_taylor', 'ataylo@university.edu', NULL, '2022-08-30 09:15:00', 'individual', 'active', 'NZ', '12 Mardon Rd, Wellington 6012', '5 Boulcott St, Wellington 6011', 'approved'),
+  (10, 'ecomplatform', 'support@ecomplatform.co', '+15165551234', '2017-03-01 13:30:00', 'business', 'active', 'US', '2525 E El Segundo Blvd, El Segundo CA 90245', NULL, 'approved');
+
+-- merchants 
+INSERT INTO consumer_div.merchants (mid, name, description, website_url, logo_url, created_at, country, state, city, postal_code, address, status, category, sub_category, mcc, contact_name, contact_email, contact_phone)
+VALUES
+  (1, 'TechMart', 'Leading electronics retailer', 'https://www.techmart.com', 'https://www.techmart.com/logo.png', '2015-01-15 00:00:00', 'US', 'California', 'Los Angeles', '90011', '645 Wilshire Blvd, Los Angeles CA 90011', 'active', 'Retail', 'Electronics', 5732, 'John Jacobs', 'jjacobs@techmart.com', '+15551234567'),
+  (2, 'FitLifeGear', 'Fitness equipment and activewear', 'https://fitlifegear.com', 'https://fitlifegear.com/brand.jpg', '2018-07-01 00:00:00', 'CA', 'Ontario', 'Toronto', 'M5V2J2', '421 Richmond St W, Toronto ON M5V2J2', 'active', 'Retail', 'Sporting Goods', 5655, 'Jane McDonald', 'jmcdonald@fitlifegear.com', '+14165559876'),
+  (3, 'UrbanDining', 'Local restaurants and cafes', 'https://www.urbandining.co', 'https://www.urbandining.co/logo.png', '2020-03-10 00:00:00', 'FR', NULL, 'Paris', '75011', '35 Rue du Faubourg Saint-Antoine, 75011 Paris', 'active', 'Food & Dining', 'Restaurants', 5812, 'Pierre Gagnon', 'pgagnon@urbandining.co', '+33612345678'),
+  (4, 'LuxStays', 'Boutique vacation rentals', 'https://luxstays.com', 'https://luxstays.com/branding.jpg', '2016-11-01 00:00:00', 'IT', NULL, 'Rome', '00187', 'Via della Conciliazione 15, Roma 00187', 'inactive', 'Travel & Hospitality', 'Accommodation', 7011, 'Marco Rossi', 'mrossi@luxstays.com', '+39061234567'),
+  (5, 'HandyCraft', 'Handmade arts and crafts supplies', 'https://handycraft.store', 'https://handycraft.store/hc-logo.png', '2022-06-20 00:00:00', 'ES', 'Catalonia', 'Barcelona', '08003', 'Passeig de Gracia 35, Barcelona 08003', 'active', 'Retail', 'Crafts & Hobbies', 5949, 'Ana Garcia', 'agarcia@handycraft.store', '+34612345678'),
+  (6, 'CodeSuite', 'SaaS productivity tools for developers', 'https://codesuite.io', 'https://codesuite.io/logo.svg', '2019-02-01 00:00:00', 'DE', NULL, 'Berlin', '10119', 'Dessauer Str 28, 10119 Berlin', 'active', 'Business Services', 'Software', 5734, 'Michael Schmidt', 'mschmidt@codesuite.io', '+49301234567'),
+  (7, 'ZenHomeGoods', 'Housewares and home decor items', 'https://www.zenhomegoods.com', 'https://www.zenhomegoods.com/branding.jpg', '2014-09-15 00:00:00', 'AU', 'Victoria', 'Melbourne', '3004', '159 Franklin St, Melbourne VIC 3004', 'active', 'Retail', 'Home & Garden', 5719, 'Emily Watson', 'ewatson@zenhomegoods.com', '+61312345678'),
+  (8, 'KidzPlayhouse', 'Children''s toys and games', 'https://kidzplayhouse.com', 'https://kidzplayhouse.com/logo.png', '2017-04-01 00:00:00', 'GB', NULL, 'London', 'WC2N 5DU', '119 Charing Cross Rd, London WC2N 5DU', 'suspended', 'Retail', 'Toys & Games', 5945, 'David Thompson', 'dthompson@kidzplayhouse.com', '+442071234567'),
+  (9, 'BeautyTrending', 'Cosmetics and beauty supplies', 'https://beautytrending.com', 'https://beautytrending.com/bt-logo.svg', '2021-10-15 00:00:00', 'NZ', NULL, 'Auckland', '1010', '129 Queen St, Auckland 1010', 'active', 'Retail', 'Health & Beauty', 5977, 'Sophie Wilson', 'swilson@beautytrending.com', '+6493012345'),
+  (10, 'GameRush', 'Video games and gaming accessories', 'https://gamerush.co', 'https://gamerush.co/gr-logo.png', '2023-02-01 00:00:00', 'US', 'New York', 'New York', '10001', '303 Park Ave S, New York NY 10001', 'active', 'Retail', 'Electronics', 5735, 'Michael Davis', 'mdavis@gamerush.co', '+16463012345');
+  
+-- coupons
+INSERT INTO consumer_div.coupons (cid, merchant_id, code, description, start_date, end_date, discount_type, discount_value, min_purchase_amount, max_discount_amount, redemption_limit, status, created_at, updated_at)
+VALUES
+  (1, 1, 'TECH20', '20% off electronics', '2023-05-01', '2023-05-31', 'percentage', 20.00, 100.00, NULL, 500, 'active', '2023-04-01 09:00:00', '2023-04-15 11:30:00'),
+  (2, 2, 'NEWYEAR30', '30% off workout gear', '2023-01-01', '2023-01-15', 'percentage', 30.00, NULL, NULL, 1000, 'expired', '2022-12-01 12:00:00', '2023-01-16 18:45:00'),
+  (3, 3, 'DINEDISCOUNT', 'Get $10 off $50 order', '2023-06-01', '2023-06-30', 'fixed_amount', 10.00, 50.00, 10.00, NULL, 'active', '2023-05-15 15:30:00', NULL), 
+  (4, 4, 'LUXESCAPE', '15% off weekly rental', '2023-07-01', '2023-08-31', 'percentage', 15.00, 1000.00, 300.00, 200, 'active', '2023-05-01 09:15:00', NULL),
+  (5, 5, 'CRAFTY10', '$10 off $75+ purchase', '2023-04-01', '2023-04-30', 'fixed_amount', 10.00, 75.00, 10.00, 300, 'inactive', '2023-03-01 14:00:00', '2023-05-05 10:30:00'),
+  (6, 6, 'CODENEW25', '25% off new subscriptions', '2023-03-01', '2023-03-31', 'percentage', 25.00, NULL, NULL, NULL, 'expired', '2023-02-15 11:00:00', '2023-04-01 09:30:00'),
+  (7, 7, 'ZENHOME', 'Get 20% off home items', '2023-09-01', '2023-09-30', 'percentage', 20.00, 50.00, NULL, 1500, 'active', '2023-08-15 16:45:00', NULL),
+  (8, 8, 'GAMEKIDS', '$15 off $100+ purchase', '2022-12-01', '2022-12-31', 'fixed_amount', 15.00, 100.00, 15.00, 800, 'expired', '2022-11-01 10:30:00', '2023-01-02 13:15:00'), 
+  (9, 9, 'GLOWUP', 'Buy 2 get 1 free on cosmetics', '2023-10-15', '2023-10-31', 'fixed_amount', 50.00, 150.00, 50.00, 300, 'active', '2023-10-01 08:00:00', NULL),
+  (10, 10, 'GAMERALERT', 'Get 25% off accessories', '2023-03-01', '2023-03-15', 'percentage', 25.00, NULL, 50.00, 750, 'expired', '2023-02-15 14:30:00', '2023-03-16 12:00:00');
+
+
+-- wallet_transactions_daily
+INSERT INTO consumer_div.wallet_transactions_daily (sender_id, sender_type, receiver_id, receiver_type, amount, status, type, description, coupon_id, created_at, completed_at, transaction_ref, gateway_name, gateway_ref, device_id, ip_address, user_agent)
+VALUES
+  (1, 0, 1, 0, 99.99, 'success', 'debit', 'Online purchase', NULL, '2023-06-01 10:15:30', '2023-06-01 10:15:45', 'ad154bf7-8185-4230-a8d8-3ef59b4e0012', 'Stripe', 'tx_123abc456def', 'mobile_8fh2k1', '192.168.0.1', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_3_1 like Mac OS X) ...'),
+  (1, 0, 1, 0, 20.00, 'success', 'credit', 'Coupon discount', 1, '2023-06-01 10:15:30', '2023-06-01 10:15:45', 'ad154bf7-8185-4230-a8d8-3ef59b4e0012', 'Stripe', 'tx_123abc456def', 'mobile_8fh2k1', '192.168.0.1', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_3_1 like Mac OS X) ...'),
+  (3, 1, 9, 0, 125.50, 'success', 'debit', 'Product purchase', NULL, '2023-06-01 13:22:18', '2023-06-01 13:22:45', 'e6f510e9-ff7d-4914-81c2-f8e56bae4012', 'PayPal', 'ppx_192ks8hl', 'web_k29qjd', '216.58.195.68', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ...'),
+  (9, 0, 3, 1, 42.75, 'success', 'debit', 'Order #438721', 3, '2023-06-01 18:45:02', '2023-06-01 18:45:13', 'b2ca190e-a42f-4f5e-8318-f82bcc6ae64e', 'Stripe', 'tx_987zyx654wvu', 'mobile_q3mz8n', '68.85.32.201', 'Mozilla/5.0 (Linux; Android 13) ...'),
+  (9, 0, 3, 1, 10.00, 'success', 'credit', 'Coupon discount', 3, '2023-06-01 18:45:02', '2023-06-01 18:45:13', 'b2ca190e-a42f-4f5e-8318-f82bcc6ae64e', 'Stripe', 'tx_987zyx654wvu', 'mobile_q3mz8n', '68.85.32.201', 'Mozilla/5.0 (Linux; Android 13) ...'),
+  (2, 0, 7, 1, 89.99, 'success', 'debit', 'Home furnishings', NULL, '2023-06-02 09:30:25', '2023-06-02 09:30:40', 'c51e10d1-db34-4d9f-b55f-43a05a5481c8', 'Checkout.com', 'ord_kzhg123', 'mobile_yjp08q', '198.51.100.233', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...'),
+  (2, 0, 7, 1, 17.99, 'success', 'credit', 'Coupon discount', 7, '2023-06-02 09:30:25', '2023-06-02 09:30:40', 'c51e10d1-db34-4d9f-b55f-43a05a5481c8', 'Checkout.com', 'ord_kzhg123', 'mobile_yjp08q', '198.51.100.233', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...'),  
+  (6, 1, 1, 0, 29.95, 'success', 'debit', 'Software subscription', NULL, '2023-06-02 14:15:00', '2023-06-02 14:15:05', '25cd48e5-08c3-4d1c-b7a4-26485ea646eb', 'Braintree', 'sub_mnb456', 'web_zz91p44l', '4.14.15.90', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ...'),
+  (4, 0, 4, 1, 2500.00, 'pending', 'debit', 'Villa rental deposit', NULL, '2023-06-02 20:45:36', NULL, 'a7659c81-0cd0-4635-af6c-cf68d2c15ab2', 'PayPal', NULL, 'mobile_34jdkl', '143.92.64.138', 'Mozilla/5.0 (Linux; Android 11; Pixel 5) ...'),
+  (5, 0, 5, 1, 55.99, 'success', 'debit', 'Craft supplies order', NULL, '2023-06-03 11:12:20', '2023-06-03 11:12:35', 'ec74cb3b-8272-4175-a5d0-f03c2e781593', 'Adyen', 'ord_tkjs87', 'web_8902wknz', '192.64.112.188', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ...'),
+  (9, 0, 9, 1, 75.00, 'success', 'debit', 'Beauty products', 9, '2023-06-04 08:00:00', '2023-06-04 08:00:25', '840a9854-1b07-422b-853c-636b289222a9', 'Checkout.com', 'ord_kio645', 'mobile_g3mjfz', '203.96.81.36', 'Mozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020) ...'),
+  (9, 0, 9, 1, 50.00, 'success', 'credit', 'Coupon discount', 9, '2023-06-04 08:00:00', '2023-06-04 08:00:25', '840a9854-1b07-422b-853c-636b289222a9', 'Checkout.com', 'ord_kio645', 'mobile_g3mjfz', '203.96.81.36', 'Mozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020) ...'),
+  (8, 0, 10, 1, 119.99, 'success', 'debit', 'New game purchase', NULL, '2023-06-04 19:30:45', '2023-06-04 19:31:10', '32e2b29c-5c7f-4906-98c5-e8abdcbfd69a', 'Braintree', 'ord_mjs337', 'web_d8180kaf', '8.26.53.165', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ...'),
+  (8, 0, 10, 1, 29.99, 'success', 'credit', 'Coupon discount', 10, '2023-06-04 19:30:45', '2023-06-04 19:31:10', '32e2b29c-5c7f-4906-98c5-e8abdcbfd69a', 'Braintree', 'ord_mjs337', 'web_d8180kaf', '8.26.53.165', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ...'),
+  (10, 1, 3, 0, 87.50, 'failed', 'debit', 'Restaurant order', NULL, '2023-06-05 12:05:21', NULL, '37cf052d-0475-4ecc-bda7-73ee904bf65c', 'Checkout.com', NULL, 'mobile_x28qlj', '92.110.51.150', 'Mozilla/5.0 (Linux; Android 13; SM-S901B) ...'),
+  (1, 0, 1, 0, 175.00, 'success', 'debit', 'Refund on order #1234', NULL, '2023-06-06 14:20:00', '2023-06-06 14:20:05', 'a331232e-a3f6-4e7f-b49f-3588bc5ff985', 'Stripe', 'rfnd_xkt521', 'web_33lq1dh', '38.75.197.8', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ...'),
+  (7, 1, 2, 0, 599.99, 'success', 'debit', 'Yearly subscription', NULL, '2023-06-06 16:55:10', '2023-06-06 16:55:15', 'ed6f46ab-9617-4d11-9aa9-60d24bdf9bc0', 'PayPal', 'sub_pjj908', 'web_zld22f', '199.59.148.201', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ...'), 
+  (2, 0, 2, 1, 22.99, 'refunded', 'debit', 'Product return', NULL, '2023-06-07 10:10:30', '2023-06-07 10:11:05', '6c97a87d-610f-4705-ae97-55071127d9ad', 'Adyen', 'tx_zcx258', 'mobile_1av8p0', '70.121.39.25', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...'),
+  (2, 0, 2, 1, 22.99, 'success', 'credit', 'Refund on return', NULL, '2023-06-07 10:10:30', '2023-06-07 10:11:05', '6c97a87d-610f-4705-ae97-55071127d9ad', 'Adyen', 'tx_zcx258', 'mobile_1av8p0', '70.121.39.25', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...');
+  
+-- wallet_user_balance_daily
+INSERT INTO consumer_div.wallet_user_balance_daily (user_id, balance, updated_at)
+VALUES
+  (1, 525.80, '2023-06-07 23:59:59'),
+  (2, 429.76, '2023-06-07 23:59:59'),
+  (3, -725.55, '2023-06-07 23:59:59'),
+  (4, -2500.00, '2023-06-07 23:59:59'),
+  (5, -55.99, '2023-06-07 23:59:59'), 
+  (6, 0.00, '2023-06-07 23:59:59'),
+  (7, 0.00, '2023-06-07 23:59:59'),
+  (8, -599.98, '2023-06-07 23:59:59'),
+  (9, -183.25, '2023-06-07 23:59:59'),
+  (10, 0.00, '2023-06-07 23:59:59');
+  
+-- wallet_merchant_balance_daily  
+INSERT INTO consumer_div.wallet_merchant_balance_daily (merchant_id, balance, updated_at)
+VALUES
+  (1, 3897.99, '2023-06-07 23:59:59'),
+  (2, 155.24, '2023-06-07 23:59:59'), 
+  (3, 2775.25, '2023-06-07 23:59:59'),
+  (4, 2500.00, '2023-06-07 23:59:59'),
+  (5, 155.99, '2023-06-07 23:59:59'),
+  (6, 29.95, '2023-06-07 23:59:59'),
+  (7, 172.98, '2023-06-07 23:59:59'), 
+  (8, 0.00, '2023-06-07 23:59:59'),
+  (9, 125.00, '2023-06-07 23:59:59'),
+  (10, 219.98, '2023-06-07 23:59:59');
+
+-- notifications
+INSERT INTO consumer_div.notifications (user_id, message, type, status, created_at, device_type, device_id, action_url)
+VALUES
+(1, 'Your order #123abc has been shipped!', 'transaction', 'unread', '2023-06-01 10:16:00', 'mobile_app', 'mobile_8fh2k1', 'app://orders/123abc'),
+(1, 'Get 20% off your next purchase! Limited time offer.', 'promotion', 'unread', '2023-06-02 09:00:00', 'email', NULL, 'https://techmart.com/promo/TECH20'),
+(2, 'A package is being returned to you. Refund processing...', 'transaction', 'read', '2023-06-07 10:12:00', 'mobile_app', 'mobile_1av8p0', 'app://orders?status=returned'),
+(2, 'Your FitLife membership is up for renewal on 7/1', 'general', 'unread', '2023-06-05 15:30:00', 'email', NULL, 'https://fitlifegear.com/renew'),
+(3, 'An order from UrbanDining was unsuccessful', 'transaction', 'read', '2023-06-05 12:06:00', 'sms', NULL, 'https://urbandining.co/orders/37cf052d'),
+(4, 'Your rental request is pending approval', 'transaction', 'unread', '2023-06-02 20:46:00', 'mobile_app', 'mobile_34jdkl', 'app://bookings/a7659c81'),
+(5, 'Claim your 25% discount on craft supplies!', 'promotion', 'archived', '2023-06-01 08:00:00', 'email', NULL, 'https://handycraft.store/CRAFTY10'),
+(6, 'Your CodeSuite subscription will renew on 7/1', 'general', 'unread', '2023-06-01 12:00:00', 'email', NULL, 'https://codesuite.io/subscriptions'),
+(7, 'Thanks for shopping at ZenHomeGoods! How did we do?', 'general', 'read', '2023-06-02 09:31:00', 'mobile_app', 'mobile_yjp08q', 'https://zenhomesurvey.com/order/c51e10d1'),
+(8, 'Playtime! New games and toys have arrived', 'promotion', 'archived', '2023-06-01 18:00:00', 'email', NULL, 'https://kidzplayhouse.com/new-arrivals'),
+(9, 'Here''s $10 to start your glow up!', 'promotion', 'unread', '2023-06-01 10:15:00', 'email', NULL, 'https://beautytrending.com/new-customer'),
+(10, 'Your order #ord_mjs337 is being processed', 'transaction', 'read', '2023-06-04 19:31:30', 'web_app', 'web_d8180kaf', 'https://gamerush.co/orders/32e2b29c');
+
+-- user_sessions
+INSERT INTO consumer_div.user_sessions (user_id, session_start_ts, session_end_ts, device_type, device_id)
+VALUES
+(1, '2023-06-01 09:45:22', '2023-06-01 10:20:35', 'mobile_app', 'mobile_8fh2k1'),
+(1, '2023-06-02 13:30:00', '2023-06-02 14:15:15', 'web_app', 'web_33lq1dh'),
+(1, '2023-06-06 14:19:00', '2023-06-06 14:22:10', 'web_app', 'web_33lq1dh'),
+(2, '2023-06-02 08:55:08', '2023-06-02 09:45:42', 'mobile_app', 'mobile_yjp08q'),
+(2, '2023-06-07 10:09:15', '2023-06-07 10:12:25', 'mobile_app', 'mobile_1av8p0'),
+(3, '2023-06-01 13:15:33', '2023-06-01 13:28:01', 'web_app', 'web_k29qjd'),
+(3, '2023-06-05 12:00:00', '2023-06-05 12:10:22', 'mobile_app', 'mobile_x28qlj'),
+(4, '2023-06-02 20:30:12', '2023-06-02 21:15:48', 'mobile_app', 'mobile_34jdkl'),
+(5, '2023-06-03 10:45:30', '2023-06-03 11:20:28', 'web_app', 'web_8902wknz'),
+(6, '2023-06-02 14:00:00', '2023-06-02 15:10:05', 'web_app', 'web_zz91p44l'),
+(7, '2023-06-06 16:45:22', '2023-06-06 17:10:40', 'web_app', 'web_zld22f'),
+(8, '2023-06-04 19:25:15', '2023-06-04 19:40:20', 'web_app', 'web_d8180kaf'),
+(8, '2023-06-01 17:30:00', '2023-06-01 18:15:35', 'mobile_app', 'mobile_q3mz8n'),
+(9, '2023-06-04 07:45:30', '2023-06-04 08:15:27', 'mobile_app', 'mobile_g3mjfz'),
+(10, '2023-06-02 14:10:15', '2023-06-02 14:40:58', 'web_app', 'web_zz91p44l');
+
+-- user_setting_snapshot
+INSERT INTO consumer_div.user_setting_snapshot (user_id, snapshot_date, tx_limit_daily, tx_limit_monthly, membership_status, password_hash, api_key, verified_devices, verified_ips, mfa_enabled, marketing_opt_in, created_at)
+VALUES
+(1, '2023-06-07', 1000.00, 5000.00, 2, 'bcryptHash($2yz9!&ka1)', '9d61c49b-8977-4914-a36b-80d1445e38fa', 'mobile_8fh2k1', '192.168.0.1', true, false, '2023-06-07 00:00:00'),
+(2, '2023-06-07', 500.00, 2500.00, 1, 'bcryptHash(qpwo9874zyGk!)', NULL, 'mobile_yjp08q, mobile_1av8p0', '198.51.100.233, 70.121.39.25', false, true, '2023-06-07 00:00:00'),
+(3, '2023-06-07', 2000.00, 10000.00, 3, 'bcryptHash(Fr3nchPa1n!@98zy)', 'e785f611-fdd8-4c2d-a870-e104358712e5', 'web_k29qjd, mobile_x28qlj', '216.58.195.68, 92.110.51.150', true, false, '2023-06-07 00:00:00'),
+(4, '2023-06-07', 5000.00, 20000.00, 4, 'bcryptHash(Vacay2023*&!Rm)', NULL, 'mobile_34jdkl', '143.92.64.138', false, true, '2023-06-07 00:00:00'),
+(5, '2023-06-07', 100.00, 500.00, 0, 'bcryptHash(cRaf7yCr8zy)', NULL, 'web_8902wknz', '192.64.112.188', false, false, '2023-06-07 00:00:00'),
+(6, '2023-06-07', 50.00, 500.00, 1, 'bcryptHash(C0d3Rul3z!99)', '6c03c175-9ac9-4854-b064-a3fff2c62e31', 'web_zz91p44l', '4.14.15.90', true, true, '2023-06-07 00:00:00'),
+(7, '2023-06-07', 250.00, 1000.00, 2, 'bcryptHash(zEnH0me&Pw7)', NULL, NULL, NULL, false, true, '2023-06-07 00:00:00'),
+(8, '2023-06-07', 200.00, 1000.00, 0, 'bcryptHash(K1dzPlay!&Rt8)', NULL, 'web_d8180kaf, mobile_q3mz8n', '8.26.53.165, 68.85.32.201', false, false, '2023-06-07 00:00:00'),
+(9, '2023-06-07', 150.00, 1000.00, 2, 'bcryptHash(Gl0wUp7!9zy)', NULL, 'mobile_g3mjfz', '203.96.81.36', true, true, '2023-06-07 00:00:00'),
+(10, '2023-06-07', 300.00, 2000.00, 1, 'bcryptHash(GamzRu1ez*&99!)', NULL, 'web_d8180kaf', '8.26.53.165', false, true, '2023-06-07 00:00:00');

--- a/defog_data/metadata.py
+++ b/defog_data/metadata.py
@@ -24,8 +24,10 @@ scholar = get_db("scholar")
 yelp = get_db("yelp")
 
 # sql-eval-instruct datasets
+broker = get_db("broker")
 car_dealership = get_db("car_dealership")
 derm_treatment = get_db("derm_treatment")
+ewallet = get_db("ewallet")
 
 dbs = {
     # sql-eval datasets
@@ -37,6 +39,8 @@ dbs = {
     "scholar": scholar,
     "yelp": yelp,
     # sql-eval-instruct datasets
+    "broker": broker,
     "car_dealership": car_dealership,
     "derm_treatment": derm_treatment,
+    "ewallet": ewallet,
 }

--- a/defog_data/supplementary.py
+++ b/defog_data/supplementary.py
@@ -63,6 +63,7 @@ def generate_embeddings(emb_path: str, save_emb: bool = True) -> tuple[dict, dic
             logging.info(f"Saved embeddings to file {emb_path}")
     return emb, csv_descriptions, glossary_emb
 
+
 def clean_glossary(glossary: str) -> list[str]:
     """
     Clean glossary by removing number bullets and periods, and making sure every line starts with a dash bullet.
@@ -81,6 +82,7 @@ def clean_glossary(glossary: str) -> list[str]:
         cleaned.append(line)
     glossary = cleaned
     return glossary
+
 
 def load_embeddings(emb_path: str) -> tuple[dict, dict]:
     """


### PR DESCRIPTION
Add `broker` and `ewallet` schema (and data):
- `broker` has camelCased table/column names and a standard prefix for all column names from the same table. `broker` also avoids the user of FOREIGN KEY/REFERENCES
- `ewallet` contains a transactional tech/e-commerce company's schema. `ewallet` has a schema name `consumer_div.` prepended to each table's name, and uses REFERENCES
Together with the earlier 2 schema:
- `car_dealership` has a sales-ish inventory schema that mimic a sales function in a company
- `derm_treatment` mimics a pharmaceutical company tracking clinical trials and various experimental treatments. It contains cohort-style data in a wide-format

We also sparsified the descriptions for the `car_dealership` schema to avoid excessively long contexts with redundant information.
Added tests to check for the number of columns for each schema.

Did a test on the number of tokens (using codellama's tokenizer) required to tokenize the sql (without the insert statements, and not using the json):
| Schema          | Num_tokens |
|-----------------|------------|
| broker          | 715        |
| car_dealership  | 867        |
| derm_treatment  | 1218       |
| ewallet         | 1484       |

And here are the number of tokens required to tokenize the glossary:
| Schema          | Num_tokens |
|-----------------|------------|
| broker          | 172        |
| car_dealership  | 265        |
| derm_treatment  | 365        |
| ewallet         | 325        |
