### PR TITLE
add data for basic

### DIFF
--- a/defog_data/broker/broker.sql
+++ b/defog_data/broker/broker.sql
@@ -68,7 +68,8 @@ INSERT INTO sbCustomer (sbCustId, sbCustName, sbCustEmail, sbCustPhone, sbCustAd
 ('C007', 'David Kim', 'david.kim@email.com', '555-370-2648', '864 Oak St', 'Anothertown', 'FL', 'USA', '33101', '2022-11-05', 'active'),
 ('C008', 'Sarah Nguyen', 'sarah.nguyen@email.com', '555-623-7419', '951 Pine Rd', 'Yourtown', 'CA', 'USA', '92101', '2019-04-01', 'closed'),
 ('C009', 'William Garcia', 'william.garcia@email.com', '555-148-5326', '258 Elm Ave', 'Anytown', 'CA', 'USA', '90001', '2021-08-22', 'active'),
-('C010', 'Jessica Hernandez', 'jessica.hernandez@email.com', '555-963-8520', '147 Cedar Blvd', 'Someville', 'NY', 'USA', '10002', '2020-03-10', 'inactive');
+('C010', 'Jessica Hernandez', 'jessica.hernandez@email.com', '555-963-8520', '147 Cedar Blvd', 'Someville', 'NY', 'USA', '10002', '2020-03-10', 'inactive'),
+('C011', 'Alex Rodriguez', 'alex.rodriguez@email.com', '555-246-1357', '753 Oak St', 'Newtown', 'NJ', 'USA', '08801', '2023-01-15', 'active');
 
 -- sbTicker  
 INSERT INTO sbTicker (sbTickerId, sbTickerSymbol, sbTickerName, sbTickerType, sbTickerExchange, sbTickerCurrency, sbTickerDb2x, sbTickerIsActive) VALUES
@@ -88,7 +89,8 @@ INSERT INTO sbTicker (sbTickerId, sbTickerSymbol, sbTickerName, sbTickerType, sb
 ('T014', 'VXUS', 'Vanguard Total International Stock ETF', 'etf', 'NASDAQ', 'USD', 'NQ', true),
 ('T015', 'VFINX', 'Vanguard 500 Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true),
 ('T016', 'VTSAX', 'Vanguard Total Stock Market Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true),  
-('T017', 'VIGAX', 'Vanguard Growth Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true);
+('T017', 'VIGAX', 'Vanguard Growth Index Fund', 'mutualfund', 'Vanguard', 'USD', 'VG', true),
+('T018', 'GOOG', 'Alphabet Inc.', 'stock', 'NASDAQ', 'USD', 'NQ', true);
 
 -- sbDailyPrice
 INSERT INTO sbDailyPrice (sbDpTickerId, sbDpDate, sbDpOpen, sbDpHigh, sbDpLow, sbDpClose, sbDpVolume, sbDpEpochMs, sbDpSource) VALUES
@@ -136,7 +138,7 @@ INSERT INTO sbTransaction (sbTxId, sbTxCustId, sbTxTickerId, sbTxDateTime, sbTxT
 ('TX009', 'C009', 'T009', '2023-04-01 15:30:00', 'buy', 50, 220.00, 11000.00, 'USD', 55.00, 10.00, 'KP009', '20230401 15:30:00', 'success'),
 ('TX010', 'C010', 'T010', '2023-04-01 16:15:00', 'sell', 80, 140.00, 11200.00, 'USD', 56.00, 10.00, 'KP010', '20230401 16:15:00', 'success'),
 ('TX011', 'C001', 'T001', '2023-04-02 09:30:00', 'sell', 50, 151.50, 7575.00, 'USD', 37.88, 5.00, 'KP011', '20230402 09:30:00', 'success'),
-('TX012', 'C002', 'T002', '2023-04-02 10:15:00', 'buy', 30, 281.25, 8437.50, 'USD', 42.19, 7.50, 'KP012', '20230402 10:15:00', 'success'),
+('TX012', 'C002', 'T002', '2023-04-02 10:15:00', 'buy', 30, 281.25, 8437.50, 'USD', 42.19, 7.50, 'KP012', '20230402 10:15:00', 'fail'),
 ('TX013', 'C003', 'T003', '2023-04-02 11:00:00', 'sell', 5, 3212.00, 16060.00, 'USD', 80.30, 15.00, 'KP013', '20230402 11:00:00', 'success'), 
 ('TX014', 'C004', 'T004', '2023-04-02 11:45:00', 'buy', 15, 184.50, 2767.50, 'USD', 13.84, 5.00, 'KP014', '20230402 11:45:00', 'success'),
 ('TX015', 'C005', 'T005', '2023-04-02 12:30:00', 'sell', 2, 2512.00, 5024.00, 'USD', 25.12, 10.00, 'KP015', '20230402 12:30:00', 'success'),
@@ -145,7 +147,7 @@ INSERT INTO sbTransaction (sbTxId, sbTxCustId, sbTxTickerId, sbTxDateTime, sbTxT
 ('TX018', 'C008', 'T008', '2023-04-02 14:45:00', 'buy', 75, 131.25, 9843.75, 'USD', 49.22, 7.50, 'KP018', '20230402 14:45:00', 'success'),
 ('TX019', 'C009', 'T009', '2023-04-02 15:30:00', 'sell', 25, 221.50, 5537.50, 'USD', 27.69, 5.00, 'KP019', '20230402 15:30:00', 'success'),
 ('TX020', 'C010', 'T010', '2023-04-02 16:15:00', 'buy', 60, 141.75, 8505.00, 'USD', 42.53, 7.50, 'KP020', '20230402 16:15:00', 'success'),
-('TX021', 'C001', 'T001', '2023-04-03 09:30:00', 'buy', 75, 152.25, 11418.75, 'USD', 57.09, 10.00, 'KP021', '20230403 09:30:00', 'success'),
+('TX021', 'C001', 'T001', '2023-04-03 09:30:00', 'buy', 75, 152.25, 11418.75, 'USD', 57.09, 10.00, 'KP021', '20230403 09:30:00', 'fail'),
 ('TX022', 'C002', 'T002', '2023-04-03 10:15:00', 'sell', 40, 283.00, 11320.00, 'USD', 56.60, 10.00, 'KP022', '20230403 10:15:00', 'success'),  
 ('TX023', 'C003', 'T003', '2023-04-03 11:00:00', 'buy', 8, 3227.00, 25816.00, 'USD', 129.08, 20.00, 'KP023', '20230403 11:00:00', 'success'),
 ('TX024', 'C004', 'T004', '2023-04-03 11:45:00', 'sell', 20, 186.25, 3725.00, 'USD', 18.63, 5.00, 'KP024', '20230403 11:45:00', 'success'),
@@ -154,4 +156,13 @@ INSERT INTO sbTransaction (sbTxId, sbTxCustId, sbTxTickerId, sbTxDateTime, sbTxT
 ('TX027', 'C007', 'T007', '2023-04-03 14:00:00', 'buy', 1, 402500.00, 402500.00, 'USD', 2012.50, 100.00, 'KP027', '20230403 14:00:00', 'success'),  
 ('TX028', 'C008', 'T008', '2023-04-03 14:45:00', 'sell', 90, 132.75, 11947.50, 'USD', 59.74, 7.50, 'KP028', '20230403 14:45:00', 'success'),
 ('TX029', 'C009', 'T009', '2023-04-03 15:30:00', 'buy', 40, 222.25, 8890.00, 'USD', 44.45, 10.00, 'KP029', '20230403 15:30:00', 'success'),
-('TX030', 'C010', 'T010', '2023-04-03 16:15:00', 'sell', 70, 142.50, 9975.00, 'USD', 49.88, 10.00, 'KP030', '20230403 16:15:00', 'success');
+('TX030', 'C010', 'T010', '2023-04-03 16:15:00', 'sell', 70, 142.50, 9975.00, 'USD', 49.88, 10.00, 'KP030', '20230403 16:15:00', 'success'),
+('TX031', 'C001', 'T001', NOW() - INTERVAL '9 days', 'buy', 100, 150.00, 15000.00, 'USD', 75.00, 10.00, 'KP031', TO_CHAR(NOW() - INTERVAL '9 days', '%Y%m%d %H:%i:%s'), 'fail'),
+('TX032', 'C002', 'T002', NOW() - INTERVAL '8 days', 'sell', 80, 280.00, 14000.00, 'USD', 70.00, 10.00, 'KP032', TO_CHAR(NOW() - INTERVAL '8 days', '%Y%m%d %H:%i:%s'), 'success'),
+('TX033', 'C003', 'T003', NOW() - INTERVAL '7 days', 'buy', 120, 200.00, 24000.00, 'USD', 120.00, 15.00, 'KP033', TO_CHAR(NOW() - INTERVAL '7 days', '%Y%m%d %H:%i:%s'), 'success'),
+('TX034', 'C004', 'T004', NOW() - INTERVAL '6 days', 'sell', 90, 320.00, 28800.00, 'USD', 144.00, 12.00, 'KP034', TO_CHAR(NOW() - INTERVAL '6 days', '%Y%m%d %H:%i:%s'), 'success'),
+('TX035', 'C005', 'T005', NOW() - INTERVAL '5 days', 'buy', 150, 180.00, 27000.00, 'USD', 135.00, 20.00, 'KP035', TO_CHAR(NOW() - INTERVAL '5 days', '%Y%m%d %H:%i:%s'), 'fail'),
+('TX036', 'C006', 'T006', NOW() - INTERVAL '4 days', 'sell', 70, 300.00, 21000.00, 'USD', 105.00, 15.00, 'KP036', TO_CHAR(NOW() - INTERVAL '4 days', '%Y%m%d %H:%i:%s'), 'success'),
+('TX037', 'C007', 'T007', NOW() - INTERVAL '3 days', 'buy', 110, 220.00, 24200.00, 'USD', 121.00, 10.00, 'KP037', TO_CHAR(NOW() - INTERVAL '3 days', '%Y%m%d %H:%i:%s'), 'success'),
+('TX038', 'C008', 'T008', NOW() - INTERVAL '2 days', 'sell', 100, 350.00, 35000.00, 'USD', 175.00, 25.00, 'KP038', TO_CHAR(NOW() - INTERVAL '2 days', '%Y%m%d %H:%i:%s'), 'success'),
+('TX039', 'C009', 'T009', NOW() - INTERVAL '1 day', 'buy', 80, 230.00, 18400.00, 'USD', 92.00, 18.00, 'KP039', TO_CHAR(NOW() - INTERVAL '1 day', '%Y%m%d %H:%i:%s'), 'pending');

--- a/defog_data/car_dealership/car_dealership.sql
+++ b/defog_data/car_dealership/car_dealership.sql
@@ -88,21 +88,33 @@ VALUES
   ('BMW', 'X5', 2023, 'Silver', '5UXCR6C56M9A12345', 'V8', 'Automatic', 62000.00),
   ('Audi', 'A4', 2022, 'Blue', 'WAUBNAF47MA098765', 'Inline 4', 'Automatic', 39000.00),
   ('Lexus', 'RX350', 2021, 'White', '2T2BZMCA7MC143210', 'V6', 'Automatic', 45500.00),
-  ('Subaru', 'Outback', 2022, 'Green', '4S4BSANC2N3246801', 'Boxer 4', 'CVT', 28000.00);
+  ('Subaru', 'Outback', 2022, 'Green', '4S4BSANC2N3246801', 'Boxer 4', 'CVT', 28000.00),
+  ('Mazda', 'CX-5', 2022, 'Red', 'JM3KE4DY4N0123456', 'Inline 4', 'Automatic', 29000.00),
+  ('Hyundai', 'Tucson', 2023, 'Black', 'KM8J3CAL3NU123456', 'Inline 4', 'Automatic', 32000.00),
+  ('Kia', 'Sorento', 2021, 'Black', '5XYPH4A50MG987654', 'V6', 'Automatic', 32000.00),
+  ('Jeep', 'Wrangler', 2022, 'Gray', '1C4HJXDG3NW123456', 'V6', 'Automatic', 38000.00),
+  ('GMC', 'Sierra 1500', 2023, 'White', '1GTU9CED3NZ123456', 'V8', 'Automatic', 45000.00),
+  ('Ram', '1500', 2022, 'Blue', '1C6SRFFT3NN123456', 'V8', 'Automatic', 42000.00),
+  ('Mercedes-Benz', 'E-Class', 2021, 'Silver', 'W1KZF8DB1MA123456', 'Inline 6', 'Automatic', 62000.00),
+  ('Volkswagen', 'Tiguan', 2022, 'Red', '3VV2B7AX1NM123456', 'Inline 4', 'Automatic', 32000.00),
+  ('Volvo', 'XC90', 2023, 'Black', 'YV4A22PK3N1234567', 'Inline 4', 'Automatic', 65000.00),
+  ('Porsche', '911', 2022, 'White', 'WP0AA2A93NS123456', 'Flat 6', 'Automatic', 120000.00);
 
 -- salespersons
 INSERT INTO salespersons (first_name, last_name, email, phone, hire_date)
 VALUES
-  ('John', 'Doe', 'john.doe@example.com', '555-123-4567', '2020-01-01'),
-  ('Jane', 'Smith', 'jane.smith@example.com', '555-987-6543', '2019-06-15'),
-  ('Michael', 'Johnson', 'michael.johnson@example.com', '555-456-7890', '2021-03-10'),
-  ('Emily', 'Brown', 'emily.brown@example.com', '555-111-2222', '2022-02-20'),
-  ('David', 'Wilson', 'david.wilson@example.com', '555-333-4444', '2020-11-05'),
+  ('John', 'Doe', 'john.doe@example.com', '555-123-4567', NOW() - INTERVAL '2 years'),
+  ('Jane', 'Smith', 'jane.smith@example.com', '555-987-6543', NOW() - INTERVAL '3 years'),
+  ('Michael', 'Johnson', 'michael.johnson@example.com', '555-456-7890', NOW() - INTERVAL '1 year'),
+  ('Emily', 'Brown', 'emily.brown@example.com', '555-111-2222', NOW() - INTERVAL '1 year'),
+  ('David', 'Wilson', 'david.wilson@example.com', '555-333-4444', NOW() - INTERVAL '2 years'),
   ('Sarah', 'Taylor', 'sarah.taylor@example.com', '555-555-6666', '2018-09-01'),
   ('Daniel', 'Anderson', 'daniel.anderson@example.com', '555-777-8888', '2021-07-12'),
   ('Olivia', 'Thomas', 'olivia.thomas@example.com', '555-999-0000', '2023-01-25'),
   ('James', 'Jackson', 'james.jackson@example.com', '555-222-3333', '2019-04-30'),
-  ('Sophia', 'White', 'sophia.white@example.com', '555-444-5555', '2022-08-18');
+  ('Sophia', 'White', 'sophia.white@example.com', '555-444-5555', '2022-08-18'),
+  ('Robert', 'Johnson', 'robert.johnson@example.com', '555-234-5678', NOW() - INTERVAL '15 days'),
+  ('Jennifer', 'Davis', 'jennifer.davis@example.com', '555-345-6789', NOW() - INTERVAL '20 days');
 
 -- customers
 INSERT INTO customers (first_name, last_name, email, phone, address, city, state, zip_code)
@@ -114,9 +126,11 @@ VALUES
   ('Henry', 'Taylor', 'henry.taylor@example.com', '555-444-3333', '654 Cedar Ln', 'Phoenix', 'AZ', '85001'),
   ('Charlotte', 'Anderson', 'charlotte.anderson@example.com', '555-333-2222', '987 Birch Dr', 'Philadelphia', 'PA', '19019'),
   ('Alexander', 'Thomas', 'alexander.thomas@example.com', '555-222-1111', '741 Walnut St', 'San Antonio', 'TX', '78006'),
-  ('Amelia', 'Jackson', 'amelia.jackson@example.com', '555-111-0000', '852 Maple Ave', 'San Diego', 'CA', '92101'),
-  ('Daniel', 'White', 'daniel.white@example.com', '555-000-9999', '963 Oak St', 'Dallas', 'TX', '75001'),
-  ('Abigail', 'Harris', 'abigail.harris@example.com', '555-999-8888', '159 Pine Ave', 'San Jose', 'CA', '95101');
+  ('Amelia', 'Jackson', 'amelia.jackson@gmail.com', '555-111-0000', '852 Maple Ave', 'San Diego', 'CA', '92101'),
+  ('Daniel', 'White', 'daniel.white@youtube.com', '555-000-9999', '963 Oak St', 'Dallas', 'TX', '75001'),
+  ('Abigail', 'Harris', 'abigail.harris@company.io', '555-999-8888', '159 Pine Ave', 'San Jose', 'CA', '95101'),
+  ('Christopher', 'Brown', 'christopher.brown@ai.com', '555-456-7890', '753 Maple Rd', 'Miami', 'FL', '33101'),
+  ('Sophia', 'Lee', 'sophia.lee@microsoft.com', '555-567-8901', '951 Oak Ln', 'Seattle', 'WA', '98101');
 
 -- sales
 INSERT INTO sales (car_id, salesperson_id, customer_id, sale_price, sale_date)
@@ -125,12 +139,17 @@ VALUES
   (3, 1, 5, 44000.00, '2023-03-20'),
   (6, 4, 2, 24500.00, '2023-03-22'),
   (8, 7, 9, 38000.00, '2023-03-25'),
-  (2, 5, 7, 21500.00, '2023-03-28'),
-  (10, 9, 1, 27000.00, '2023-04-01'),
+  (2, 4, 7, 21500.00, '2023-03-28'),
+  (10, 6, 1, 27000.00, '2023-04-01'),
   (5, 3, 6, 26000.00, '2023-04-05'),
-  (7, 8, 10, 60000.00, '2023-04-10'),
+  (7, 2, 10, 60000.00, '2023-04-10'),
   (4, 6, 8, 40000.00, '2023-04-12'),
-  (9, 10, 4, 44500.00, '2023-04-15');
+  (9, 2, 4, 44500.00, '2023-04-15'),
+  (1, 7, 11, 28000.00, NOW() - INTERVAL '32 days'),
+  (3, 3, 12, 43500.00, NOW() - INTERVAL '10 days'),
+  (6, 1, 11, 24000.00, NOW() - INTERVAL '15 days'),
+  (2, 3, 1, 17200.00, NOW() - INTERVAL '30 days'),
+  (8, 6, 12, 37500.00, NOW() - INTERVAL '29 days');
 
 -- inventory_snapshots
 INSERT INTO inventory_snapshots (snapshot_date, car_id, is_in_inventory)

--- a/defog_data/derm_treatment/derm_treatment.sql
+++ b/defog_data/derm_treatment/derm_treatment.sql
@@ -128,7 +128,10 @@ VALUES
 ('David', 'Wilson', '1965-09-30', 'Male', 'david@email.com', '555-369-2580', '321 Pine Ln', 'Somewhere', 'FL', '13579', 'medicaid', 'GHI901234', 175, 78),
 ('Eve', 'Brown', '2000-01-01', 'Female', 'eve@email.com', '555-147-2589', '654 Cedar St', 'Nowhere', 'WA', '97531', 'uninsured', NULL, 160, 55),
 ('Frank', 'Taylor', '1988-05-12', 'Male', 'frank@email.com', '555-753-9514', '987 Birch Dr', 'Anyplace', 'CO', '24680', 'private', 'JKL567890', 183, 90),
-('Grace', 'Anderson', '1975-12-25', 'Female', 'grace@email.com', '555-951-7532', '159 Maple Rd', 'Somewhere', 'OH', '86420', 'medicare', 'MNO246810', 170, 68);
+('Grace', 'Anderson', '1975-12-25', 'Female', 'grace@email.com', '555-951-7532', '159 Maple Rd', 'Somewhere', 'OH', '86420', 'medicare', 'MNO246810', 170, 68),
+('Hannah', 'Garcia', '1982-08-05', 'Female', 'hannah@email.com', '555-369-1470', '753 Walnut Ave', 'Somewhere', 'CA', '97531', 'private', 'PQR135790', 162, 57),
+('Isaac', 'Martinez', '1995-02-18', 'Male', 'isaac@email.com', '555-147-8520', '951 Spruce Blvd', 'Anytown', 'TX', '13579', 'medicaid', 'STU024680', 178, 82);
+
 
 INSERT INTO drugs (drug_name, manufacturer, drug_type, moa, fda_appr_dt, admin_route, dos_amt, dos_unit, dos_freq_hrs, ndc)
 VALUES  
@@ -137,7 +140,11 @@ VALUES
 ('Topizol', 'BioMed Ltd', 'topical', 'PDE4 inhibitor', '2018-11-01', 'topical', 15, 'g', 12, '98765-432-10'),
 ('Biologic-X', 'Innova Biologics', 'biologic', 'IL-23 inhibitor', NULL, 'injection', 100, 'mg', 672, '13579-246-80'), 
 ('Smallazine', 'Chem Co', 'small molecule', 'JAK inhibitor', '2020-03-15', 'oral', 5, 'mg', 24, '97531-864-20'),
-('Topicort', 'Derma Rx', 'topical', 'Corticosteroid', '2005-09-30', 'topical', 30, 'g', 12, '24680-135-79'); 
+('Topicort', 'Derma Rx', 'topical', 'Corticosteroid', '2005-09-30', 'topical', 30, 'g', 12, '24680-135-79'),
+('Biologic-Y', 'BioPharm Inc', 'biologic', 'IL-12/23 inhibitor', '2012-07-01', 'injection', 50, 'mg', 504, '75319-951-46'),
+('Smallitol', 'PharmaGen', 'small molecule', 'IL-6 inhibitor', '2017-04-15', 'oral', 10, 'mg', 24, '36915-258-07'),
+('Topicalin', 'DermiCare', 'topical', 'Calcineurin inhibitor', '2019-10-01', 'topical', 20, 'g', 12, '14785-369-02'),
+('Biologic-Z', 'BioMed Ltd', 'biologic', 'IL-17F inhibitor', '2021-01-01', 'injection', 80, 'mg', 336, '95146-753-19');
 
 INSERT INTO diagnoses (diag_code, diag_name, diag_desc)
 VALUES
@@ -156,20 +163,29 @@ VALUES
 INSERT INTO treatments (patient_id, doc_id, drug_id, diag_id, start_dt, end_dt, is_placebo, tot_drug_amt, drug_unit)
 VALUES
 (1, 1, 1, 1, '2022-01-01', '2022-06-30', false, 240, 'mg'),
-(2, 2, 2, 2, '2022-02-15', '2022-08-14', false, 180, 'mg'),
+(2, 2, 2, 2, '2022-02-15', '2022-08-14', true, 180, 'mg'),
 (3, 3, 3, 3, '2022-03-10', '2022-09-09', false, 360, 'g'),
 (4, 4, 4, 4, '2022-04-01', NULL, false, 200, 'mg'),
 (5, 5, 5, 5, '2022-05-01', '2022-10-31', false, 180, 'mg'),
 (6, 6, 6, 6, '2022-06-15', '2022-12-14', false, 720, 'g'),
-(1, 7, 1, 7, '2022-07-01', '2022-12-31', false, 240, 'mg'),
+(1, 7, 1, 7, '2022-07-01', '2022-12-31', true, 240, 'mg'),
 (2, 1, 2, 8, '2022-08-01', '2023-01-31', false, 180, 'mg'),
 (3, 2, 3, 9, '2022-09-01', '2023-02-28', false, 360, 'g'),
 (4, 3, 4, 10, '2022-10-01', NULL, true, 0, NULL),
-(5, 4, 5, 1, '2022-11-01', '2023-04-30', false, 180, 'mg'),
+(5, 4, 5, 1, '2022-11-01', '2023-04-30', true, 180, 'mg'),
 (6, 5, 6, 2, '2022-12-01', '2023-05-31', false, 720, 'g'),
 (7, 6, 1, 3, '2023-01-01', '2023-06-30', false, 240, 'mg'),
 (1, 7, 2, 4, '2023-02-01', '2023-07-31', false, 180, 'mg'),
-(2, 1, 3, 5, '2023-03-01', '2023-08-31', false, 360, 'g');
+(2, 1, 3, 5, '2023-03-01', '2023-08-31', false, 360, 'g'),
+(1, 2, 4, 6, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '7 months'), DATE_TRUNC('month', CURRENT_DATE - INTERVAL '2 months'), false, 300, 'mg'),
+(2, 5, 1, 8, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '6 month'), DATE_TRUNC('month', CURRENT_DATE - INTERVAL '4 months'), false, 80, 'mg'),
+(3, 6, 2, 9, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '5 months'), NULL, true, 200, 'mg'),
+(1, 7, 3, 10, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '4 months'), NULL, false, 150, 'g'),
+(2, 1, 4, 1, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '3 months'), NULL, false, 100, 'mg'),
+(3, 2, 5, 2, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '2 months'), NULL, false, 250, 'mg'),
+(1, 3, 6, 3, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month'), NULL, false, 300, 'g'),
+(2, 4, 1, 4, CURRENT_DATE, NULL, true, 200, 'mg'),
+(3, 5, 2, 5, CURRENT_DATE, NULL, false, 150, 'mg');
 
 INSERT INTO outcomes (treatment_id, assess_dt, day7_lesion_cnt, day30_lesion_cnt, day100_lesion_cnt, day7_pasi_score, day30_pasi_score, day100_pasi_score, day7_tewl, day30_tewl, day100_tewl, day7_itch_vas, day30_itch_vas, day100_itch_vas, day7_hfg, day30_hfg, day100_hfg)  
 VALUES
@@ -187,7 +203,9 @@ VALUES
 (12, '2022-12-08', 29, 23, 11, 17.4, 12.3, 4.9, 21.8, 18.7, 14.8, 78, 58, 38, 0.6, 1.6, 3.1),
 (13, '2023-01-08', 18, 12, 3, 10.5, 6.1, 1.0, 16.9, 14.3, 11.0, 56, 36, 16, 1.9, 2.9, 4.4),
 (14, '2023-02-08', 27, 20, 10, 16.2, 11.1, 4.1, 21.0, 17.9, 14.1, 74, 54, 34, 0.5, 1.5, 3.0), 
-(15, '2023-03-08', 20, 14, 4, 11.8, 7.3, 1.7, 17.8, 15.2, 11.8, 60, 40, 20, 1.6, 2.6, 4.1);
+(15, '2023-03-08', 20, 14, 4, 11.8, 7.3, 1.7, 17.8, 15.2, 11.8, 60, 40, 20, 1.6, 2.6, 4.1),
+(16, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '5 months') + INTERVAL '7 days', 24, 18, 8, 14.4, 9.6, 3.2, 20.4, 17.4, 13.7, 70, 50, 30, 0.9, 1.9, 3.4),
+(17, DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month') + INTERVAL '7 days', 22, 16, NULL, 13.2, 8.8, NULL, 19.1, 16.3, NULL, 65, 45, NULL, 1.3, 2.3, NULL);
 
 INSERT INTO adverse_events (treatment_id, reported_dt, description)
 VALUES  

--- a/defog_data/ewallet/ewallet.sql
+++ b/defog_data/ewallet/ewallet.sql
@@ -138,7 +138,11 @@ VALUES
   (7, 'shopsmart', 'customerserv@shopsmart.biz', '+6585771234', '2020-09-15 06:25:00', 'business', 'inactive', 'SG', '888 Orchard Rd, #05-000, Singapore 238801', NULL, 'approved'),
   (8, 'michael_brown', 'mike.brown@outlook.com', '+3912378624', '2019-07-22 16:40:00', 'individual', 'active', 'DE', 'Heidestr 17, Berlin 10557', 'Heidestr 17, Berlin 10557', 'approved'),
   (9, 'alex_taylor', 'ataylo@university.edu', NULL, '2022-08-30 09:15:00', 'individual', 'active', 'NZ', '12 Mardon Rd, Wellington 6012', '5 Boulcott St, Wellington 6011', 'approved'),
-  (10, 'ecomplatform', 'support@ecomplatform.co', '+15165551234', '2017-03-01 13:30:00', 'business', 'active', 'US', '2525 E El Segundo Blvd, El Segundo CA 90245', NULL, 'approved');
+  (10, 'huang2143', 'huang2143@example.com', '+8612345678901', '2023-12-10 08:00:00', 'individual', 'active', 'CN', '123 Nanjing Road, Shanghai 200000', '123 Nanjing Road, Shanghai 200000', 'approved'),
+  (11, 'lisa_jones', 'lisa.jones@email.com', '+6123456789', '2023-09-05 15:20:00', 'individual', 'active', 'AU', '789 George St, Sydney NSW 2000', '789 George St, Sydney NSW 2000', 'approved'),
+  (12, 'thomas_smith', 'thomas.smith@email.com', '+441234567890', '2023-10-18 11:45:00', 'individual', 'inactive', 'GB', '456 High St, London SW1 1AA', '456 High St, London SW1 1AA', 'pending'),
+  (13, 'amy_patel', 'amy.patel@email.com', '+918765432109', '2024-02-28 09:30:00', 'individual', 'active', 'IN', '789 MG Road, Mumbai 400001', '789 MG Road, Mumbai 400001', 'approved');
+
 
 -- merchants 
 INSERT INTO consumer_div.merchants (mid, name, description, website_url, logo_url, created_at, country, state, city, postal_code, address, status, category, sub_category, mcc, contact_name, contact_email, contact_phone)
@@ -152,8 +156,13 @@ VALUES
   (7, 'ZenHomeGoods', 'Housewares and home decor items', 'https://www.zenhomegoods.com', 'https://www.zenhomegoods.com/branding.jpg', '2014-09-15 00:00:00', 'AU', 'Victoria', 'Melbourne', '3004', '159 Franklin St, Melbourne VIC 3004', 'active', 'Retail', 'Home & Garden', 5719, 'Emily Watson', 'ewatson@zenhomegoods.com', '+61312345678'),
   (8, 'KidzPlayhouse', 'Children''s toys and games', 'https://kidzplayhouse.com', 'https://kidzplayhouse.com/logo.png', '2017-04-01 00:00:00', 'GB', NULL, 'London', 'WC2N 5DU', '119 Charing Cross Rd, London WC2N 5DU', 'suspended', 'Retail', 'Toys & Games', 5945, 'David Thompson', 'dthompson@kidzplayhouse.com', '+442071234567'),
   (9, 'BeautyTrending', 'Cosmetics and beauty supplies', 'https://beautytrending.com', 'https://beautytrending.com/bt-logo.svg', '2021-10-15 00:00:00', 'NZ', NULL, 'Auckland', '1010', '129 Queen St, Auckland 1010', 'active', 'Retail', 'Health & Beauty', 5977, 'Sophie Wilson', 'swilson@beautytrending.com', '+6493012345'),
-  (10, 'GameRush', 'Video games and gaming accessories', 'https://gamerush.co', 'https://gamerush.co/gr-logo.png', '2023-02-01 00:00:00', 'US', 'New York', 'New York', '10001', '303 Park Ave S, New York NY 10001', 'active', 'Retail', 'Electronics', 5735, 'Michael Davis', 'mdavis@gamerush.co', '+16463012345');
-  
+  (10, 'GameRush', 'Video games and gaming accessories', 'https://gamerush.co', 'https://gamerush.co/gr-logo.png', '2023-02-01 00:00:00', 'US', 'New York', 'New York', '10001', '303 Park Ave S, New York NY 10001', 'active', 'Retail', 'Electronics', 5735, 'Michael Davis', 'mdavis@gamerush.co', '+16463012345'),
+  (11, 'FashionTrend', 'Trendy clothing and accessories', 'https://www.fashiontrend.com', 'https://www.fashiontrend.com/logo.png', '2019-08-10 00:00:00', 'UK', NULL, 'Manchester', 'M2 4WU', '87 Deansgate, Manchester M2 4WU', 'active', 'Retail', 'Apparel', 5651, 'Emma Thompson', 'ethompson@fashiontrend.com', '+441612345678'),
+  (12, 'GreenGourmet', 'Organic foods and natural products', 'https://www.greengourmet.com', 'https://www.greengourmet.com/logo.jpg', '2020-12-05 00:00:00', 'CA', 'British Columbia', 'Vancouver', 'V6B 6B1', '850 W Hastings St, Vancouver BC V6B 6B1', 'active', 'Food & Dining', 'Groceries', 5411, 'Daniel Lee', 'dlee@greengourmet.com', '+16041234567'),
+  (13, 'PetParadise', 'Pet supplies and accessories', 'https://petparadise.com', 'https://petparadise.com/logo.png', '2018-03-20 00:00:00', 'AU', 'New South Wales', 'Sydney', '2000', '275 Pitt St, Sydney NSW 2000', 'active', 'Retail', 'Pets', 5995, 'Olivia Johnson', 'ojohnson@petparadise.com', '+61298765432'),
+  (14, 'HomeTechSolutions', 'Smart home devices and gadgets', 'https://hometechsolutions.net', 'https://hometechsolutions.net/logo.png', '2022-04-15 00:00:00', 'US', 'California', 'San Francisco', '94105', '350 Mission St, San Francisco CA 94105', 'active', 'Retail', 'Home Appliances', 5734, 'Ethan Brown', 'ebrown@hometechsolutions.net', '+14159876543'),
+  (15, 'BookWorms', 'Books and reading accessories', 'https://bookworms.co.uk', 'https://bookworms.co.uk/logo.png', '2017-06-30 00:00:00', 'UK', NULL, 'London', 'WC2H 9JA', '66-67 Tottenham Court Rd, London WC2H 9JA', 'active', 'Retail', 'Books', 5942, 'Sophia Turner', 'sturner@bookworms.co.uk', '+442078912345');
+
 -- coupons
 INSERT INTO consumer_div.coupons (cid, merchant_id, code, description, start_date, end_date, discount_type, discount_value, min_purchase_amount, max_discount_amount, redemption_limit, status, created_at, updated_at)
 VALUES
@@ -190,7 +199,13 @@ VALUES
   (1, 0, 1, 0, 175.00, 'success', 'debit', 'Refund on order #1234', NULL, '2023-06-06 14:20:00', '2023-06-06 14:20:05', 'a331232e-a3f6-4e7f-b49f-3588bc5ff985', 'Stripe', 'rfnd_xkt521', 'web_33lq1dh', '38.75.197.8', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ...'),
   (7, 1, 2, 0, 599.99, 'success', 'debit', 'Yearly subscription', NULL, '2023-06-06 16:55:10', '2023-06-06 16:55:15', 'ed6f46ab-9617-4d11-9aa9-60d24bdf9bc0', 'PayPal', 'sub_pjj908', 'web_zld22f', '199.59.148.201', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ...'), 
   (2, 0, 2, 1, 22.99, 'refunded', 'debit', 'Product return', NULL, '2023-06-07 10:10:30', '2023-06-07 10:11:05', '6c97a87d-610f-4705-ae97-55071127d9ad', 'Adyen', 'tx_zcx258', 'mobile_1av8p0', '70.121.39.25', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...'),
-  (2, 0, 2, 1, 22.99, 'success', 'credit', 'Refund on return', NULL, '2023-06-07 10:10:30', '2023-06-07 10:11:05', '6c97a87d-610f-4705-ae97-55071127d9ad', 'Adyen', 'tx_zcx258', 'mobile_1av8p0', '70.121.39.25', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...');
+  (2, 0, 2, 1, 22.99, 'success', 'credit', 'Refund on return', NULL, '2023-06-07 10:10:30', '2023-06-07 10:11:05', '6c97a87d-610f-4705-ae97-55071127d9ad', 'Adyen', 'tx_zcx258', 'mobile_1av8p0', '70.121.39.25', 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) ...'),
+  (1, 0, 2, 1, 49.99, 'success', 'debit', 'Product purchase', NULL, NOW() - INTERVAL '5 months', NOW() - INTERVAL '5 months', 'tx_ref_11_1', 'Stripe', 'stripe_ref_11_1', 'device_11_1', '192.168.1.11', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36'),
+  (4, 0, 3, 1, 99.99, 'success', 'debit', 'Service purchase', NULL, NOW() - INTERVAL '4 months', NOW() - INTERVAL '4 months', 'tx_ref_12_1', 'PayPal', 'paypal_ref_12_1', 'device_12_1', '192.168.1.12', 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1'),
+  (4, 0, 1, 1, 149.99, 'success', 'debit', 'Subscription purchase', NULL, NOW() - INTERVAL '3 months', NOW() - INTERVAL '3 months', 'tx_ref_13_1', 'Stripe', 'stripe_ref_13_1', 'device_13_1', '192.168.1.13', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36'),
+  (2, 0, 5, 1, 199.99, 'success', 'debit', 'Product purchase', NULL, NOW() - INTERVAL '2 months', NOW() - INTERVAL '2 months', 'tx_ref_14_1', 'PayPal', 'paypal_ref_14_1', 'device_14_1', '192.168.1.14', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0'),
+  (2, 0, 1, 1, 249.99, 'success', 'debit', 'Service purchase', NULL, NOW() - INTERVAL '1 month', NOW() - INTERVAL '1 month', 'tx_ref_15_1', 'Stripe', 'stripe_ref_15_1', 'device_15_1', '192.168.1.15', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36');
+
   
 -- wallet_user_balance_daily
 INSERT INTO consumer_div.wallet_user_balance_daily (user_id, balance, updated_at)


### PR DESCRIPTION
Add/modify data for schema used in the basic instruct eval questions.
Note that due to the nature of the data being relative to the time when `./setup.sh` was run (ie when the records were inserted into the DB), for example:
```sql
('TX039', 'C009', 'T009', NOW() - INTERVAL '1 day', 'buy', 80, 230.00, 18400.00, 'USD', 92.00, 18.00, 'KP039', TO_CHAR(NOW() - INTERVAL '1 day', '%Y%m%d %H:%i:%s'), 'pending');
```
Hence, we would need to re-run `./setup.sh` before each evaluation run.