### PR TITLE
Dialect fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ dist/
 
 # IDE
 .vscode/
+
+# BigQuery, MySQL, SQLite and TSQL files
+*_bigquery.sql 
+*_mysql.sql
+*_sqlite.sql
+*_tsql.sql
+sqlite_dbs/

--- a/utils_dialects.py
+++ b/utils_dialects.py
@@ -38,7 +38,7 @@ def fix_ddl_bigquery(translated_ddl):
     #     r"DEFAULT\s+('[^']*'|\d+|[a-zA-Z_]+\(\))", "", translated_ddl
     # )
     translated_ddl = re.sub(
-        r"SERIAL(PRIMARY KEY)?", "STRING DEFAULT GENERATE_UUID()", translated_ddl
+        r"SERIAL(PRIMARY KEY)?", "INT64", translated_ddl
     )
     translated_ddl = translated_ddl.replace("EXTRACT(EPOCH FROM ", "UNIX_SECONDS(")
     translated_ddl = re.sub(

--- a/utils_dialects.py
+++ b/utils_dialects.py
@@ -494,6 +494,11 @@ def create_tsql_db(db_name):
     except Exception as e:
         print(f"Error creating tables for `{db_name}`: {e}")
         raise
+    finally:
+        if "cursor" in locals():
+            cursor.close()
+        if "conn" in locals():
+            conn.close()
 
 
 def test_query_db(db_name, dialect, test_queries):


### PR DESCRIPTION
- Because SERIAL is not supported by BigQuery, change SERIAL data type to INT64 to match inserted values. And GENERATE_UUID while similar in intent only supports string types.
- Clean up SQL Server connection so that the DB can be properly deleted
- Added dialect sql files to .gitignore so that each time we edit the original postgres .sql files, we can simply regenerate the .sql files for the other dialects without having to manually edit them. Also prevents this repo from bloating.