### PR TITLE
Add data to break ties

### DIFF
--- a/defog_data/scholar/scholar.sql
+++ b/defog_data/scholar/scholar.sql
@@ -80,7 +80,12 @@ INSERT INTO public.author (authorid, authorname) VALUES
 (2, 'Emily Johnson'),
 (3, 'Michael Brown'),
 (4, 'Sarah Davis'),
-(5, 'David Wilson')
+(5, 'David Wilson'),
+(6, 'Jennifer Lee'),
+(7, 'Robert Moore'),
+(8, 'Linda Taylor'),
+(9, 'William Anderson'),
+(10, 'Karen Martinez')
 ;
 
 INSERT INTO public.cite (citingpaperid, citedpaperid) VALUES
@@ -177,7 +182,11 @@ INSERT INTO public.writes (paperid, authorid) VALUES
 (4, 5),
 (5, 1),
 (2, 1),
-(4, 3)
+(4, 3),
+(4, 6),
+(2, 7),
+(2, 8),
+(2, 9)
 ;
 
 


### PR DESCRIPTION
Add data to `scholar` to break ties, as mentioned in this [sql-eval review](https://github.com/defog-ai/sql-eval/pull/151#pullrequestreview-2092751021)

Previously:
```
scholar=# SELECT paper.paperid, paper.title, COUNT(DISTINCT writes.authorid) AS num_authors FROM paper JOIN writes ON paper.paperid = writes.paperid GROUP BY 1,2 ORDER BY num
_authors DESC;
 paperid |                    title                     | num_authors 
---------+----------------------------------------------+-------------
       1 | A Study on Machine Learning Algorithms       |           3
       2 | The Effects of Climate Change on Agriculture |           3
       4 | COVID-19 Impact on Society                   |           3
       5 | Machine Learning in Tackling Climate Change  |           2
       3 | Social Media and Mental Health               |           1
```

Now:
```
scholar=# SELECT paper.paperid, paper.title, COUNT(DISTINCT writes.authorid) AS num_authors FROM paper JOIN writes ON paper.paperid = writes.paperid GROUP BY 1,2 ORDER BY num_authors DESC;
 paperid |                    title                     | num_authors 
---------+----------------------------------------------+-------------
       2 | The Effects of Climate Change on Agriculture |           6
       4 | COVID-19 Impact on Society                   |           4
       1 | A Study on Machine Learning Algorithms       |           3
       5 | Machine Learning in Tackling Climate Change  |           2
       3 | Social Media and Mental Health               |           1
```