### PR TITLE
clarify month interval

### DIFF
--- a/defog_data/ewallet/ewallet.sql
+++ b/defog_data/ewallet/ewallet.sql
@@ -285,7 +285,7 @@ VALUES
 (8, '2023-06-01 17:30:00', '2023-06-01 18:15:35', 'mobile_app', 'mobile_q3mz8n'),
 (9, '2023-06-04 07:45:30', '2023-06-04 08:15:27', 'mobile_app', 'mobile_g3mjfz'),
 (10, '2023-06-02 14:10:15', '2023-06-02 14:40:58', 'web_app', 'web_zz91p44l'),
-(5, CURRENT_TIMESTAMP - INTERVAL '31 days', CURRENT_TIMESTAMP - INTERVAL '31 days' + INTERVAL '15 min', 'web_app', 'web_8902wknz'),
+(5, CURRENT_TIMESTAMP - INTERVAL '1 month 1 day', CURRENT_TIMESTAMP - INTERVAL '1 month 1 day' + INTERVAL '15 min', 'web_app', 'web_8902wknz'),
 (6, CURRENT_TIMESTAMP - INTERVAL '8 days', CURRENT_TIMESTAMP - INTERVAL '8 days' + INTERVAL '15 min', 'web_app', 'web_zz91p44l'),
 (7, CURRENT_TIMESTAMP - INTERVAL '5 days', CURRENT_TIMESTAMP - INTERVAL '5 days' + INTERVAL '15 min', 'web_app', 'web_zz91p44l'),
 (8, CURRENT_TIMESTAMP - INTERVAL '3 days', CURRENT_TIMESTAMP - INTERVAL '3 days' + INTERVAL '15 min', 'web_app', 'web_d8180kaf'),


### PR DESCRIPTION
We have a question in sql-eval advanced that goes like this:
question: What is the TUC in the past month, inclusive of 1 month ago? Return the total count.
instructions: TUC = Total number of user sessions in the past month

golden_query:
```sql
SELECT
  COUNT(*) AS TUC
FROM
  consumer_div.user_sessions
WHERE
  session_start_ts >= CURRENT_DATE - INTERVAL '1 month'
  OR session_end_ts >= CURRENT_DATE - INTERVAL '1 month'
```
alternative query that should be fine (since the instruction doesn't state whether the user session in the month considers the start/end time:
```sql
SELECT
  COUNT(*) AS TUC
FROM
  consumer_div.user_sessions AS us
WHERE
  us.session_start_ts >= CURRENT_TIMESTAMP - INTERVAL '1 MONTH';
```
previously our data would fail the 2nd query whenever our current date's past month has 31 days, firstly because the `session_start_ts` would be exactly 1 month ago. When one setups the database, there is almost always certainly going to be a lag between the `current_timestamp - interval '31 days'` inserted vs the actual time when it's queried. depending on whether it's 15 minutes before, equals, or after the insertion of the record, we will have different results from the golden query, which isn't ideal. Hence to eliminate this ambiguity, we adjust our data accordingly by letting the SQL engine handle the month interval, instead of us manually adjusting the number of days. We keep this record because we still want to have the ability to test for data within the past month.