### PR TITLE
Update data

### DIFF
--- a/defog_data/advising/advising.sql
+++ b/defog_data/advising/advising.sql
@@ -259,7 +259,9 @@ INSERT INTO public.semester (semester_id, semester, year) VALUES
 INSERT INTO public.student (student_id, lastname, firstname, program_id, declare_major, total_credit, total_gpa, entered_as, admit_term, predicted_graduation_semester, degree, minor, internship) VALUES
 (1, 'Smith', 'John', 1, 'Computer Science', 13, 3.5, 'Freshman','2018-01-01', '2022-05-01', 'Bachelor of Science', NULL, NULL),
 (2, 'Doe', 'Jane', 1, 'Computer Science', 7, 3.2, 'Freshman', '2018-01-01', '2022-05-01', 'Bachelor of Science', NULL, NULL),
-(3, 'Johnson', 'David', 2, 'Mathematics', 7, 3.6, 'Freshman', '2019-01-01', '2022-05-01', 'Bachelor of Arts', 'Mathematics', NULL)
+(3, 'Johnson', 'David', 2, 'Mathematics', 7, 3.6, 'Freshman', '2019-01-01', '2022-05-01', 'Bachelor of Arts', 'Mathematics', NULL),
+(4, 'Brown', 'Sarah', 3, 'Physics', 7, 3.8, 'Freshman', CURRENT_DATE - INTERVAL '15 years', CURRENT_DATE - INTERVAL '11 years', 'Bachelor of Science', 'Physics', NULL),
+(5, 'Wilson', 'Michael', 1, 'Computer Science', 7, 3.2, 'Freshman', CURRENT_DATE - INTERVAL '13 years', CURRENT_DATE - INTERVAL '9 years', 'Bachelor of Science', NULL, NULL)
 ;
 
 INSERT INTO public.student_record (student_id, course_id, semester, grade, how, transfer_source, earn_credit, repeat_term, test_id, offering_id) VALUES

--- a/defog_data/yelp/yelp.sql
+++ b/defog_data/yelp/yelp.sql
@@ -128,7 +128,10 @@ INSERT INTO public.review (rid, business_id, user_id, rating, text, year, month)
 (17, 'mno345', '2', 4.6, 'Superb.', 2022, 'July'),
 (18, 'jkl012', '3', 5.0, 'WOwowow.', 2022, 'August'),
 (19, 'jkl012', '4', 4.8, 'Lovin it.', 2022, 'September'),
-(20, 'ghi789', '5', 1.5, 'Worst experience ever.', 2022, 'October')
+(20, 'ghi789', '5', 1.5, 'Worst experience ever.', EXTRACT(YEAR FROM CURRENT_DATE - INTERVAL '15 months'), TO_CHAR(CURRENT_DATE - INTERVAL '15 months', 'Month')),
+(21, 'abc123', '1', 4.6, 'Very goody.', EXTRACT(YEAR FROM CURRENT_DATE - INTERVAL '9 months'), TO_CHAR(CURRENT_DATE - INTERVAL '9 months', 'Month')),
+(22, 'def456', '2', 3.0, 'Average', EXTRACT(YEAR FROM CURRENT_DATE - INTERVAL '8 months'), TO_CHAR(CURRENT_DATE - INTERVAL '8 months', 'Month')),
+(23, 'ghi789', '3', 4.0, 'Not bad.', EXTRACT(YEAR FROM CURRENT_DATE - INTERVAL '7 months'), TO_CHAR(CURRENT_DATE - INTERVAL '7 months', 'Month'))
 ;
 
 INSERT INTO public.tip (tip_id, business_id, text, user_id, likes, year, month) VALUES


### PR DESCRIPTION
We make the following data changes:
* Add students graduating in < 10 and > 10 years for advising. This is to allow our data to test if the SQL contains a filter for the past 10 years for the following question: `How many students were predicted to graduate in the last 10 years?`. Currently all of the available data is within the "past 10 years" hence it won't test if the SQL actually filtered correctly for the past 10 years.
* Add reviews < 10 and > 10 months to allow our data to test if SQL accurately filters past 10 months since today.