### PR TITLE
Update yelp business.review_count to be internally consistent

### DIFF
--- a/defog_data/advising/advising.sql
+++ b/defog_data/advising/advising.sql
@@ -176,10 +176,10 @@ INSERT INTO public.comment_instructor (instructor_id, student_id, score, comment
 ;
 
 INSERT INTO public.course (course_id, name, department, number, credits, advisory_requirement, enforced_requirement, description, num_semesters, num_enrolled, has_discussion, has_lab, has_projects, has_exams, num_reviews, clarity_score, easiness_score, helpfulness_score) VALUES
-(1, 'Introduction to Computer Science', 'Computer Science', 'CS101', '3', NULL, NULL, 'This course introduces the basics of computer science.', 2, 2, true, false, true, false, 10, 5, 3, 4),
-(2, 'Advanced Calculus', 'Mathematics', 'MATH201', '4', 'CS101', NULL, 'This course covers advanced topics in calculus.', 1, 3, false, false, true, true, 5, 4, 2, 3),
+(1, 'Introduction to Computer Science', 'Computer Science', 'CS101', '3', NULL, NULL, 'This course introduces the basics of computer science.', 2, 3, true, false, true, false, 10, 5, 3, 4),
+(2, 'Advanced Calculus', 'Mathematics', 'MATH201', '4', 'CS101', NULL, 'This course covers advanced topics in calculus.', 1, 5, false, false, true, true, 5, 4, 2, 3),
 (3, 'Introduction to Physics', 'Physics', 'PHYS101', '3', NULL, 'MATH201', 'This course provides an introduction to physics principles.', 2, 1, true, true, true, true, 8, 4, 3, 5),
-(4, 'Distributed Databases', 'Computer Science', 'CS302', '3', NULL, 'CS101', 'This course provides an introduction to distributed databases.', 2, 2, true, true, false, true, 4, 2, 1, 5)
+(4, 'Distributed Databases', 'Computer Science', 'CS302', '3', NULL, 'CS101', 'This course provides an introduction to distributed databases.', 2, 3, true, true, false, true, 4, 2, 1, 5)
 ;
 
 INSERT INTO public.course_offering (offering_id, course_id, semester, section_number, start_time, end_time, monday, tuesday, wednesday, thursday, friday, saturday, sunday, has_final_project, has_final_exam, textbook, class_address, allow_audit) VALUES

--- a/defog_data/advising/advising.sql
+++ b/defog_data/advising/advising.sql
@@ -272,5 +272,9 @@ INSERT INTO public.student_record (student_id, course_id, semester, grade, how, 
 (2, 2, 1, 'C', 'in-person', NULL, 'Yes', NULL, '1', 2),
 (2, 1, 1, 'B', 'online', NULL, 'Yes', NULL, '1', 1),
 (3, 2, 1, 'B+', 'in-person', NULL, 'Yes', NULL, '1', 2),
-(3, 4, 2, 'B+', 'in-person', NULL, 'Yes', NULL, '1', 4)
+(3, 4, 2, 'B+', 'in-person', NULL, 'Yes', NULL, '1', 4),
+(4, 2, 1, 'C', 'in-person', NULL, 'Yes', NULL, '1', 2),
+(4, 1, 1, 'B', 'online', NULL, 'Yes', NULL, '1', 1),
+(5, 2, 1, 'B+', 'in-person', NULL, 'Yes', NULL, '1', 2),
+(5, 4, 2, 'B+', 'in-person', NULL, 'Yes', NULL, '1', 4)
 ;

--- a/defog_data/yelp/yelp.json
+++ b/defog_data/yelp/yelp.json
@@ -95,7 +95,7 @@
             {
                 "data_type": "bigint",
                 "column_name": "count",
-                "column_description": "Number of check-ins on the given day"
+                "column_description": "Total number of check-ins at a business on a given day"
             },
             {
                 "data_type": "text",

--- a/defog_data/yelp/yelp.sql
+++ b/defog_data/yelp/yelp.sql
@@ -64,9 +64,9 @@ CREATE TABLE public.users (
 
 
 INSERT INTO public.business (bid, business_id, name, full_address, city, latitude, longitude, review_count, is_open, state) VALUES
-(1, 'abc123', 'Joe’s Pizza', '123 Main St', 'San Francisco', '37.7749295', '-122.4194155', 2, 0, 'CA'),
-(2, 'def456', 'Peter’s Cafe', '456 Elm St', 'New York', '40.712776', '-74.005974', 3, 1, 'NY'),
-(3, 'ghi789', 'Anna’s Diner', '789 Oak St', 'Los Angeles', '34.052235', '-118.243683', 4, 0, 'CA'),
+(1, 'abc123', 'Joe’s Pizza', '123 Main St', 'San Francisco', '37.7749295', '-122.4194155', 3, 0, 'CA'),
+(2, 'def456', 'Peter’s Cafe', '456 Elm St', 'New York', '40.712776', '-74.005974', 4, 1, 'NY'),
+(3, 'ghi789', 'Anna’s Diner', '789 Oak St', 'Los Angeles', '34.052235', '-118.243683', 5, 0, 'CA'),
 (4, 'jkl012', 'Mark’s Bistro', '012 Maple St', 'San Francisco', '37.7749295', '-122.4194155', 4, 1, 'CA'),
 (5, 'mno345', 'Lily’s Bakery', '345 Walnut St', 'New York', '40.712776', '-74.005974', 3, 1, 'NY'),
 (6, 'xyz123', 'Izza’s Pizza', '83 Main St', 'San Francisco', '37.8749295', '-122.5194155', 2, 1, 'CA'),


### PR DESCRIPTION
Updated the `business.review_count` values for 3 rows in `yelp` so that they are internally consistent with the changes made in #38 

Also updated the `student_record` values in `advising` to make them more internally consistent with the changes made in #38 

Also updated the column description of checkin.count for clarity